### PR TITLE
remove date filter from food list

### DIFF
--- a/www/activities/food-list/js/food-list.js
+++ b/www/activities/food-list/js/food-list.js
@@ -28,12 +28,9 @@ var foodList = {
   {
     return new Promise(function(resolve, reject){
 
-      var dateTime = app.getDateAtMidnight();
-      dateTime.setUTCDate(dateTime.getUTCDate()+1); //Go a day ahead just to be sure.
-
       foodList.list = []; //Clear list
 
-      dbHandler.getIndex("dateTime", "foodList").openCursor(IDBKeyRange.upperBound(dateTime), "prev").onsuccess = function(e)
+      dbHandler.getIndex("dateTime", "foodList").openCursor(null, "prev").onsuccess = function(e)
       {
         var cursor = e.target.result;
 


### PR DESCRIPTION
This was incorrect after the UTC change because food item dates could be
more than one day ahead of UTC midnight.

Passing null will return all records, which I believe is the intent.

This fixes a bug introduced in b01f0be0d7e8d91591dd548c21e6ab4dee539645 where a food item disappears from the food list after being added to the diary, because the new timestamp is more than one day ahead of UTC midnight.
