### PR TITLE
clear data after edit-meal form is shown

### DIFF
--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -335,6 +335,8 @@ $(document).on("show", "#edit-meal", function(){
     meals.fillEditForm(this.data) //Populate edit screen with data
     .then(() => meals.validateEditForm());
   }
+
+  this.data = {};
 });
 
 //Edit meal name


### PR DESCRIPTION
This stops items from being added to a recipe when back is pressed on the food
list.

Fixes #85