### PR TITLE
Food list search fixes

### DIFF
--- a/www/activities/food-list/js/food-list.js
+++ b/www/activities/food-list/js/food-list.js
@@ -600,7 +600,7 @@ $(document).on("init", "#food-list-page", function(e){
   });
 });
 
-$(document).on("keyup", "#food-list-page #filter", function(e){
+$(document).on("input", "#food-list-page #filter", function(e){
 
   $("#food-list-page ons-toolbar-button#submit").hide(); //Hide submit button until items are checked
   $("#food-list-page ons-toolbar-button#scan").show(); //show scan button

--- a/www/activities/food-list/js/food-list.js
+++ b/www/activities/food-list/js/food-list.js
@@ -47,11 +47,15 @@ var foodList = {
     });
   },
 
-  filterList : function(term)
+  setFilter : function(term)
   {
-    return filteredList = foodList.list.filter(function (el) {
-      return (el.name.match(new RegExp(term, "i")) || el.brand.match(new RegExp(term, "i"))); //Allow partial match and case insensitive
-    });
+    var list = this.list;
+    if (term) {
+      //Allow partial match and case insensitive
+      var exp = new RegExp(term, "i");
+      list = list.filter(el => el.name.match(exp) || el.brand.match(exp));
+    }
+    this.populate(list);
   },
 
   populate : function(list)
@@ -605,17 +609,7 @@ $(document).on("input", "#food-list-page #filter", function(e){
   $("#food-list-page ons-toolbar-button#submit").hide(); //Hide submit button until items are checked
   $("#food-list-page ons-toolbar-button#scan").show(); //show scan button
 
-  if (this.value == "") //Search box cleared, reset the list
-  {
-    foodList.fillListFromDB()
-    .then(function(){
-      foodList.populate(foodList.list);
-    });
-  }
-  else { //Filter the list
-    var filteredList = foodList.filterList(this.value);
-    foodList.populate(filteredList);
-  }
+  foodList.setFilter(this.value);
 });
 
 //Delete/Edit item from food list by holding


### PR DESCRIPTION
I have a lot of problems with the food list search box if I rapidly change the search text.  Sometimes duplicate items will appear, sometimes the app will become unresponsive.  If you have a big list of food items on an android device, try rapidly entering and removing a single char from the search box, and you'll probably see what I mean.

I think these are mostly caused by the async update when you clear the search box.  Rather than making async searches work reliably, which would involve queueing or cancelling them somehow, I just took out the DB update.  If you can think of a reason it needs to be there, let me know, but filtering never changes the master list of food items, so I don't see why it would be required.

It seems much more stable to me now.