### PR TITLE
use temporary food list for OFF search results

### DIFF
--- a/www/activities/food-list/js/food-list.js
+++ b/www/activities/food-list/js/food-list.js
@@ -347,14 +347,13 @@ var foodList = {
         {
           var products = result.products;
 
-          foodList.list = []; //Clear list
-          var item = {};
+          var list = []; //Clear list
           for (var i = 0; i <  products.length; i++)
           {
-            item = foodList.parseOFFProduct(products[i]);
-            foodList.list.push(item);
+            var item = foodList.parseOFFProduct(products[i]);
+            list.push(item);
           }
-          foodList.populate(foodList.list);
+          foodList.populate(list);
           $("#food-list-page ons-progress-circular").hide(); //Circular progress indicator
         }
       }


### PR DESCRIPTION
Here's my fix for the OFF search problem introduced in #98 

We just populate from a temporary list when we get search results and leave the db list in `foodList.list` intact.  This is similar to filtering.

The only behaviour that's changed is that after you have OFF results, if you change the text in the search box, it will go back to filtering the local list until you submit the search again.  Personally, I think that's sensible behaviour.

Now `foodList.list` always stores the latest view of the db, so it only needs to be repopulated after writes to the databse.  I verified that it still updates correctly after adding and deleting items from OFF.