### PR TITLE
Fix the diary date display for timezones ahead of UTC

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -142,9 +142,9 @@ app.Diary = {
 
   updateDateDisplay: function() {
     let el = app.Diary.el.date;
-    let months = app.strings.months || ['january', 'february', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    let months = app.strings.months || ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     let date = new Date(app.Diary.date);
-    let dateString = date.getUTCDate() + " " + months[date.getUTCMonth()] + " " + date.getUTCFullYear();
+    let dateString = date.getDate() + " " + months[date.getMonth()] + " " + date.getFullYear();
     el.innerText = dateString;
   },
 


### PR DESCRIPTION
When starting the app and going into the diary the displayed date was from the previous day (local timezone for me is UTC+2). 
The diary stores the current day in the local timezone ignoring the hour and minute. When filling the date display the app would use the UTC values for day, month and year of the stored date which causes it to display the previous day for timezones ahead of UTC.

This PR just uses the local timezone day, month and year which fixes this problem.  

I also capitalized the first character of the fallback month names. I don't know whether these fallback is even needed because the month names are in the default locale and the devices locale is merged with default locale to work around missing values.