### PR TITLE
Fix incorrect calculation of nutrition in diary nutrition card

### DIFF
--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -189,7 +189,11 @@ app.FoodsMealsRecipes = {
       if (ids.recipe !== undefined && ids.recipe.length > 0)
         recipes = await dbHandler.getByMultipleKeys(ids.recipe, "recipes");
 
-      let data = foods.concat(recipes);
+      let data = [];
+      items.forEach((item) => {
+        let match = recipes.find(x => x.id === item.id) || foods.find(x => x.id === item.id)
+        data.push(match)
+      })
 
       if (data.length > 0) {
 


### PR DESCRIPTION
When using the app I noticed that sometimes the nutrition card in the top of the diary would display incorrect values for the  day when using foods and recipes. 

This happens because when the app calculates the total nutrition values of the diary entries it will look up foods and recipes separately in the database and concatenate these results in a list. This results in the result list having a different order than the diary entries. 

When the total nutrition is calculated the app uses the result list and the item portion and quantity in the diary entries resulting in the incorrect calculation because of the mixed up order.

This PR does not concatenate foods and recipes but merges them together in the same order as in the diary entries which fixes the problem.