### PR TITLE
Add dark theme to Chart.js charts

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -118,7 +118,6 @@ app.DiaryChart = {
       options: {
         legend: {
           labels: {
-            fontColor: 'black',
             fontSize: 18
           }
         }

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -183,9 +183,11 @@ app.Settings = {
     if (darkMode === true) {
       body.className = colourTheme + " theme-dark";
       panel.style["background-color"] = "black";
+      Chart.defaults.global.defaultFontColor = 'white';
     } else {
       body.className = colourTheme;
       panel.style["background-color"] = "white";
+      Chart.defaults.global.defaultFontColor = 'black';
     }
   },
 

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -276,7 +276,6 @@ app.Stats = {
   },
 
   renderChart: function(data) {
-    Chart.defaults.global.defaultFontColor = 'black';
     app.Stats.chart = new Chart(app.Stats.el.chart, {
       type: app.Stats.chartType,
       data: {
@@ -299,7 +298,6 @@ app.Stats = {
         },
         legend: {
           labels: {
-            fontColor: 'black',
             fontSize: 16
           }
         }


### PR DESCRIPTION
Currently Chart.js charts ignore the dark mode and their labels font color is black which makes it unreadable if the user has enabled dark mode. 

This PR changes the label font color to white when Dark Mode is enabled.