### PR TITLE
Ignore timezone information for diary dateTime key

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -306,7 +306,8 @@ app.Diary = {
   getEntryFromDB: function() {
     return new Promise(async function(resolve, reject) {
       if (app.Diary.date !== undefined) {
-        let entry = await dbHandler.get("diary", "dateTime", new Date(app.Diary.date));
+        let date = new Date(app.Diary.date)
+        let entry = await dbHandler.get("diary", "dateTime", new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())));
         resolve(entry);
       }
     }).catch(err => {
@@ -315,8 +316,9 @@ app.Diary = {
   },
 
   getNewEntry: function() {
+    let date = new Date(app.Diary.date)
     let entry = {
-      dateTime: new Date(app.Diary.date),
+      dateTime: new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())),
       items: [],
       stats: {},
     };


### PR DESCRIPTION
Currently timezone information is stored in the key of a diary entry. E.g. an entry for 2nd May of 2021 in GMT+2 will be saved as 2021-05-01T22:00:00.000Z (UTC). This can lead to problems for people who live in countries with daylight saving time or who travel to a country with a different timezone since they won't be able to see the entries they have previously made whilst they are in the different timezone because the hours are in the key. 

You can test this by changing the timezone of your device and trying to view a previously entered diary entry or by exporting the database and viewing the dateTime fields of the diary store.

This PR takes the day, month and year (ignoring hours) of the users time and saves it as UTC yyyy-mm-ddT00:00:00.000Z and thereby avoiding this problem. In combination with https://github.com/davidhealey/waistline/pull/231 it is also guaranteed that the correct date will be show in the diary date display.
It will also upgrade the database to store the dateTime fields as previously described.

I have tested upgrading the database and importing a backup of version=30 and it worked for me. If you have any suggestions or see any problems (maybe traveling from a timezone ahead of GMT to a timezone behind GMT and vice versa) with this approach let me know.