### PR TITLE
Add weekday to the diary date display and use toLocaleDateString for formatting

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -142,9 +142,8 @@ app.Diary = {
 
   updateDateDisplay: function() {
     let el = app.Diary.el.date;
-    let months = app.strings.months || ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     let date = new Date(app.Diary.date);
-    let dateString = date.getDate() + " " + months[date.getMonth()] + " " + date.getFullYear();
+    let dateString = date.toLocaleDateString([], {weekday: "short", month: "long", day: "numeric", year: "numeric"})
     el.innerText = dateString;
   },
 


### PR DESCRIPTION
This PR adds the weekday to the date display in the diary and uses toLocaleDateString to format it.

I added the weekday since I think it is a useful information especially when looking up what have you eaten on previous days.

I am not sure about the formatting of the weekday since there are 3 variants: `narrow`, `short` and `long`. I did not consider `narrow` since it looks unusual to me (maybe personal preferences based on how dates are formatted in Germany). I personally prefer `long` but I think it is better to use `short` since it's less likely to overflow the display and it is also used in Googe Calendar and my Android Lock Screen.

Regardless of whether we add weekdays or not: The date should be formatted with toLocaleDateString to properly format it in all locales. It also translates the months and weekdays so afaik you could remove translations for months in Crowdin since it is not used anywhere else in the app.

Below you can find a demo for all weekday formats in the locales of the app.

<details><summary> Locale: bg</summary>
  narrow

    п, 3 май 2021 г.
    в, 4 май 2021 г.
    с, 5 май 2021 г.
    ч, 6 май 2021 г.
    п, 7 май 2021 г.
    с, 8 май 2021 г.
    н, 9 май 2021 г.
  short

    пн, 3 май 2021 г.
    вт, 4 май 2021 г.
    ср, 5 май 2021 г.
    чт, 6 май 2021 г.
    пт, 7 май 2021 г.
    сб, 8 май 2021 г.
    нд, 9 май 2021 г.
  long

    понеделник, 3 май 2021 г.
    вторник, 4 май 2021 г.
    сряда, 5 май 2021 г.
    четвъртък, 6 май 2021 г.
    петък, 7 май 2021 г.
    събота, 8 май 2021 г.
    неделя, 9 май 2021 г.
</details><details><summary> Locale: de</summary>
  narrow

    M, 3. Mai 2021
    D, 4. Mai 2021
    M, 5. Mai 2021
    D, 6. Mai 2021
    F, 7. Mai 2021
    S, 8. Mai 2021
    S, 9. Mai 2021
  short

    Mo., 3. Mai 2021
    Di., 4. Mai 2021
    Mi., 5. Mai 2021
    Do., 6. Mai 2021
    Fr., 7. Mai 2021
    Sa., 8. Mai 2021
    So., 9. Mai 2021
  long

    Montag, 3. Mai 2021
    Dienstag, 4. Mai 2021
    Mittwoch, 5. Mai 2021
    Donnerstag, 6. Mai 2021
    Freitag, 7. Mai 2021
    Samstag, 8. Mai 2021
    Sonntag, 9. Mai 2021
</details><details><summary> Locale: en</summary>
  narrow

    M, May 3, 2021
    T, May 4, 2021
    W, May 5, 2021
    T, May 6, 2021
    F, May 7, 2021
    S, May 8, 2021
    S, May 9, 2021
  short

    Mon, May 3, 2021
    Tue, May 4, 2021
    Wed, May 5, 2021
    Thu, May 6, 2021
    Fri, May 7, 2021
    Sat, May 8, 2021
    Sun, May 9, 2021
  long

    Monday, May 3, 2021
    Tuesday, May 4, 2021
    Wednesday, May 5, 2021
    Thursday, May 6, 2021
    Friday, May 7, 2021
    Saturday, May 8, 2021
    Sunday, May 9, 2021
</details><details><summary> Locale: fi</summary>
  narrow

    M 3. toukokuuta 2021
    T 4. toukokuuta 2021
    K 5. toukokuuta 2021
    T 6. toukokuuta 2021
    P 7. toukokuuta 2021
    L 8. toukokuuta 2021
    S 9. toukokuuta 2021
  short

    ma 3. toukokuuta 2021
    ti 4. toukokuuta 2021
    ke 5. toukokuuta 2021
    to 6. toukokuuta 2021
    pe 7. toukokuuta 2021
    la 8. toukokuuta 2021
    su 9. toukokuuta 2021
  long

    maanantaina 3. toukokuuta 2021
    tiistaina 4. toukokuuta 2021
    keskiviikkona 5. toukokuuta 2021
    torstaina 6. toukokuuta 2021
    perjantaina 7. toukokuuta 2021
    lauantaina 8. toukokuuta 2021
    sunnuntaina 9. toukokuuta 2021
</details><details><summary> Locale: fr</summary>
  narrow

    L 3 mai 2021
    M 4 mai 2021
    M 5 mai 2021
    J 6 mai 2021
    V 7 mai 2021
    S 8 mai 2021
    D 9 mai 2021
  short

    lun. 3 mai 2021
    mar. 4 mai 2021
    mer. 5 mai 2021
    jeu. 6 mai 2021
    ven. 7 mai 2021
    sam. 8 mai 2021
    dim. 9 mai 2021
  long

    lundi 3 mai 2021
    mardi 4 mai 2021
    mercredi 5 mai 2021
    jeudi 6 mai 2021
    vendredi 7 mai 2021
    samedi 8 mai 2021
    dimanche 9 mai 2021
</details><details><summary> Locale: he</summary>
  narrow

    ב׳, 3 במאי 2021
    ג׳, 4 במאי 2021
    ד׳, 5 במאי 2021
    ה׳, 6 במאי 2021
    ו׳, 7 במאי 2021
    ש׳, 8 במאי 2021
    א׳, 9 במאי 2021
  short

    יום ב׳, 3 במאי 2021
    יום ג׳, 4 במאי 2021
    יום ד׳, 5 במאי 2021
    יום ה׳, 6 במאי 2021
    יום ו׳, 7 במאי 2021
    שבת, 8 במאי 2021
    יום א׳, 9 במאי 2021
  long

    יום שני, 3 במאי 2021
    יום שלישי, 4 במאי 2021
    יום רביעי, 5 במאי 2021
    יום חמישי, 6 במאי 2021
    יום שישי, 7 במאי 2021
    יום שבת, 8 במאי 2021
    יום ראשון, 9 במאי 2021
</details><details><summary> Locale: ru</summary>
  narrow

    пн, 3 мая 2021 г.
    вт, 4 мая 2021 г.
    ср, 5 мая 2021 г.
    чт, 6 мая 2021 г.
    пт, 7 мая 2021 г.
    сб, 8 мая 2021 г.
    вс, 9 мая 2021 г.
  short

    пн, 3 мая 2021 г.
    вт, 4 мая 2021 г.
    ср, 5 мая 2021 г.
    чт, 6 мая 2021 г.
    пт, 7 мая 2021 г.
    сб, 8 мая 2021 г.
    вс, 9 мая 2021 г.
  long

    понедельник, 3 мая 2021 г.
    вторник, 4 мая 2021 г.
    среда, 5 мая 2021 г.
    четверг, 6 мая 2021 г.
    пятница, 7 мая 2021 г.
    суббота, 8 мая 2021 г.
    воскресенье, 9 мая 2021 г.
</details><details><summary> Locale: sv</summary>
  narrow

    M 3 maj 2021
    T 4 maj 2021
    O 5 maj 2021
    T 6 maj 2021
    F 7 maj 2021
    L 8 maj 2021
    S 9 maj 2021
  short

    mån 3 maj 2021
    tis 4 maj 2021
    ons 5 maj 2021
    tors 6 maj 2021
    fre 7 maj 2021
    lör 8 maj 2021
    sön 9 maj 2021
  long

    måndag 3 maj 2021
    tisdag 4 maj 2021
    onsdag 5 maj 2021
    torsdag 6 maj 2021
    fredag 7 maj 2021
    lördag 8 maj 2021
    söndag 9 maj 2021
</details>
