### PR TITLE
hide seconds in diary timestamps

### DIFF
--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -456,7 +456,7 @@ app.FoodsMealsRecipes = {
         if (timestamp == true && item.dateTime !== undefined) {
           let dateTime = new Date(item.dateTime);
           if (text != "") text += "<br>";
-          text += dateTime.toLocaleTimeString();
+          text += dateTime.toLocaleTimeString([],{hour: '2-digit', minute:'2-digit'});
         }
 
         details.innerHTML = text;


### PR DESCRIPTION
This PR hides the seconds in the timestamps for items in the diary for the sake of simplicity since I feel that this is not a valuable information a user is interested in (and it looks better without :smile:). From what I have tested it perfectly works with 12 hour (keeps AM/PM) and 24 hour format.