### PR TITLE
Fix misassigning log object to weight in db-handler

### DIFF
--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -223,11 +223,11 @@ var dbHandler = {
 
             store.openCursor().onsuccess = function(event) {
               let cursor = event.target.result;
-              if (cursor) {
+              if (cursor && cursor.value && cursor.value.weight) {
                 let value = cursor.value;
                 let dateTime = value.dateTime.toDateString();
 
-                weights[dateTime] = value;
+                weights[dateTime] = value.weight;
                 cursor.continue();
               } else {
                 resolve();


### PR DESCRIPTION
A logs object from the old schema was beign assigned to weight property
in the new schema, yielding unexpected behaviour even though the import
completed successfully.

Example of log object (waistline_export.json -> log[0]):
```json
{
    "dateTime": "2021-05-03T00:00:00.000Z",
    "nutrition": {
        "calories": 2461.0960000000005
    },
    "weight": "72.5",
    "goals": {
        "weight": {
            "target": "67.95",
            "weekly": "0.629",
            "gain": false
        }
    }
}
```

Actual migration result (waistline_export.json -> diary[0].stats):
```json
{
        "weight": {
            "dateTime": "2021-05-03T00:00:00.000Z",
            "goals": {
                "weight": {
                    "gain": false,
                    "target": "67.95",
                    "weekly": "0.629"
                }
            },
            "nutrition": {
                "calories": 2461.0960000000005
            },
            "weight": "72.5"
        }
}

```

Expected migration result:
```json
{
        "weight": "72.5"
}

```