### PR TITLE
Update carbs, protein and sugar to new names in db-handler

### DIFF
--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -309,6 +309,11 @@ var dbHandler = {
         await new Promise(function(resolve, reject) {
           store = transaction.objectStore('foodList');
           let foods = [];
+          const renamedProperties = {
+            "carbs": "carbohydrates",
+            "protein": "proteins",
+            "sugar": "sugars"
+          };
 
           store.openCursor().onsuccess = function(event) {
 
@@ -316,6 +321,15 @@ var dbHandler = {
 
             if (cursor) {
               let item = cursor.value;
+
+              if (item.nutrition !== undefined) {
+                Object.keys(renamedProperties).forEach(oldProperty => {
+                  if (item.nutrition[oldProperty]) {
+                    item.nutrition[renamedProperties[oldProperty]] = item.nutrition[oldProperty];
+                    delete item.nutrition[oldProperty];
+                  }
+                })
+              }
 
               if (item.portion !== undefined) {
                 item.portion = parseInt(cursor.value.portion);


### PR DESCRIPTION
Those properties were renamed recently and `foodList` is being migrated with
the old names yet, statistics use foodList's nutrition facts to
aggregate data based on diary reference to foodList's id for each item.
Thus, statistics screen doesn't show carbohydrates, proteins and sugars.

Example of old `item.nutrition`:
```json
"nutrition": {
    "calories": 137,
    "carbs": 25.95,
    "fat": 1.5,
    "fiber": 1.5,
    "protein": 4.4,
    "salt": 0,
    "saturated-fat": 0.32,
    "sodium": 304000,
    "sugar": 0.12
}
```

Example of `item.nutrition` migrated from old version to new one:
```json
{
    "calories": 137,
    "carbs": 25.95,
    "fat": 1.5,
    "fiber": 1.5,
    "protein": 4.4,
    "salt": 0,
    "saturated-fat": 0.32,
    "sodium": 304000,
    "sugar": 0.12
}
```

Example of `item.nutrition` created directly at the new version:
```json
{
    "calories": 137,
    "carbohydrates": 25.95,
    "fat": 1.5,
    "fiber": 1.5,
    "proteins": 4.4,
    "saturated-fat": 0.32,
    "sodium": 304,
    "sugars": 0.12
}
```