### PR TITLE
Pass parameters to barcode scanner plugin

### DIFF
--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -357,6 +357,13 @@ app.Foodlist = {
         } else {
           resolve(undefined);
         }
+      },
+      async (error) => {
+        resolve(undefined);
+      },
+      {
+        showTorchButton: true,
+        disableSuccessBeep: true
       });
     });
   },


### PR DESCRIPTION
This PR adds two parameters to the barcodeScanner function call. The loud beep sound mentioned in #183 has bugged me for quite a while, so I added a parameter to disable it. While I was at it, I also added a parameter to show a toggle button for turning the phone's torch light on and off. This could be useful for scanning a barcode when there is insufficient ambient lighting.

I successfully tested these features on my own Android phone to make sure that they work.

I guess one could also add a setting to enable/disable these features, but I don't think that's necessary. I can't really imagine anyone who would prefer to hear a loud sound every time they scan something. And the torch toggle button is only displayed in the corner as an option, no one is forced to use it.