### PR TITLE
Animations enabled/disabled fix

### DIFF
--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -395,7 +395,7 @@ app.Settings = {
         usda: false
       },
       appearance: {
-        animations: true,
+        animations: false,
         "dark-mode": false,
         "start-page": "/settings/",
         theme: "color-theme-red",

--- a/www/index.js
+++ b/www/index.js
@@ -286,7 +286,7 @@ let animate = true;
 let settings = JSON.parse(window.localStorage.getItem("settings"));
 
 if (settings != undefined && settings.appearance !== undefined && settings.appearance.animations !== undefined)
-  animate = settings.appearance.animations;
+  animate = !settings.appearance.animations;
 
 let viewOptions = {
   animate: animate


### PR DESCRIPTION
This fixes a bug where some animations were enabled when the setting to "Disable UI animations" was turned on.
I also changed the default setting so for new users animations are not disabled. I think it makes more sense this way.