### PR TITLE
Fix missing context menus

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -409,6 +409,13 @@ document.addEventListener('deviceready', async function() {
   }, 2000);
 }, false);
 
+// Prevent chrome displaying context menu on long click
+window.addEventListener("contextmenu", (e) => {
+  let target = e.target.nodeName.toLowerCase();
+  if (target !== "input" && target !== "textarea")
+    e.preventDefault();
+});
+
 // Android back button 
 document.addEventListener("backbutton", (e) => {
 

--- a/www/index.js
+++ b/www/index.js
@@ -409,11 +409,6 @@ document.addEventListener('deviceready', async function() {
   }, 2000);
 }, false);
 
-//Prevent chrome displaying context menu on long click
-window.addEventListener("contextmenu", (e) => {
-  e.preventDefault();
-});
-
 // Android back button 
 document.addEventListener("backbutton", (e) => {
 


### PR DESCRIPTION
Removing the following lines from index.js fixes #251 (missing copy/paste option) on my phone.

```js
//Prevent chrome displaying context menu on long click
window.addEventListener("contextmenu", (e) => {
  e.preventDefault();
});
```