### PR TITLE
Cleanup after branch merges

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -69,18 +69,25 @@ app.DiaryChart = {
       };
 
       const nutrition = await app.FoodsMealsRecipes.getTotalNutrition(data.items[0]);
-      const macros = ["fat", "saturated-fat", "carbohydrates", "sugars", "proteins"];
-      let sum = 0;
+      const macros = app.energyMacroNutriments;
+
+      let energy = {};
+      let energyTotal = 0;
 
       // Chart
       macros.forEach((x, i) => {
 
-        let value = nutrition[x] || 0;
+        let amount = nutrition[x] || 0;
+        let caloriesPerUnit = app.Goals.getMacroNutrimentCalories(x);
+        energy[x] = amount * caloriesPerUnit;
+
         if (x == "fat")
-          value -= nutrition["saturated-fat"] || 0;
+          amount -= nutrition["saturated-fat"] || 0;
         else if (x == "carbohydrates")
-          value -= nutrition["sugars"] || 0;
-        sum += value;
+          amount -= nutrition["sugars"] || 0;
+
+        let value = amount * caloriesPerUnit;
+        energyTotal += value;
 
         if (value > 0) {
           let name = app.strings.nutriments[x] || x;
@@ -95,7 +102,7 @@ app.DiaryChart = {
         if (x == "saturated-fat" || x == "sugars") return;
         if (!nutrition[x]) return;
 
-        let percent = nutrition[x] / sum * 100;
+        let percent = energy[x] / energyTotal * 100;
         let name = app.strings.nutriments[x] || x;
 
         if (x == "fat" && nutrition["saturated-fat"] !== undefined && nutrition["saturated-fat"] !== 0) {

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -203,7 +203,6 @@ app.Diary = {
 
       let x = nutriments[i];
 
-      // Skip calories if energyUnit is "kJ" and skip kilojoules if energyUnit is "kcal"
       if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) continue;
 
       if (!app.Goals.showInDiary(x)) continue;
@@ -232,7 +231,7 @@ app.Diary = {
       title.id = x + "-title";
 
       let text = app.strings.nutriments[x] || x;
-      let t = document.createTextNode(app.Utils.tidyText(text, 20, true));
+      let t = document.createTextNode(app.Utils.tidyText(text, 50, true));
       title.appendChild(t);
       rows[0].appendChild(title);
 
@@ -244,18 +243,11 @@ app.Diary = {
       let span = document.createElement("span");
       t = document.createTextNode("0");
 
-      if (nutrition) {
-        if (x !== "calories" && x !== "kilojoules") {
-          let value = nutrition[x] || 0;
-          t.nodeValue = parseFloat(value.toFixed(2));
-        } else {
-          let energy = nutrition.calories || 0;
-
-          if (energyUnit == "kJ")
-            energy = Math.round(energy * 4.1868);
-
-          t.nodeValue = energy.toFixed(0);
-        }
+      if (nutrition !== undefined && nutrition[x] !== undefined) {
+        if (x !== "calories" && x !== "kilojoules")
+          t.nodeValue = parseFloat(nutrition[x].toFixed(2));
+        else
+          t.nodeValue = nutrition[x].toFixed(0);
       }
 
       // Set value text colour
@@ -593,18 +585,11 @@ app.Diary = {
       let unit = nutrimentUnits[x] || "g";
       let value = 0;
 
-      if (nutrition) {
-        if (x !== "calories" && x !== "kilojoules") {
-          let v = nutrition[x] || 0;
-          value = parseFloat(v.toFixed(2));
-        } else {
-          let energy = nutrition.calories || 0;
-
-          if (energyUnit == "kJ")
-            energy = Math.round(energy * 4.1868);
-
-          value = energy.toFixed(0);
-        }
+      if (nutrition !== undefined && nutrition[x] !== undefined) {
+        if (x !== "calories" && x !== "kilojoules")
+          value = parseFloat(nutrition[x].toFixed(2));
+        else
+          value = nutrition[x].toFixed(0);
       }
 
       if (value == 0) continue;

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -120,11 +120,7 @@ app.Group = {
 
     let right = document.createElement("div");
     right.className = "col-25 energy link icon-only";
-    
-    let value = nutrition.calories || 0;
-
-    if (energyUnit == "kJ")
-      value = Math.round(value * 4.1868);
+    let value = nutrition[energyName] || 0;
 
     right.addEventListener("click", function(e) {
       app.Diary.showCategoryNutriments(id, nutrition);

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -143,8 +143,8 @@ app.Goals = {
 
   getEnergyPercentGoal: function(stat, percentGoal, energyUnit, energyGoal) {
     // Convert energy goal to calories
-    if (energyUnit == "kJ")
-      energyGoal = energyGoal * 0.23900573614
+    if (energyUnit == app.nutrimentUnits.kilojoules)
+      energyGoal = app.Utils.convertUnit(energyGoal, app.nutrimentUnits.kilojoules, app.nutrimentUnits.calories);
 
     let caloriesPerUnit = app.Goals.getMacroNutrimentCalories(stat);
     let result = Math.round(percentGoal / 100 * energyGoal / caloriesPerUnit);

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -123,17 +123,20 @@ app.Stats = {
 
   populateDropdownOptions: function() {
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    const nutrimentUnits = app.nutrimentUnits;
+    const energyUnit = app.Settings.get("units", "energy");
     const measurements = app.measurements;
     const stats = measurements.concat(nutriments);
 
     stats.forEach((x, i) => {
-      if (app.Goals.showInStats(x)) {
-        let option = document.createElement("option");
-        option.value = x;
-        let text = app.strings.nutriments[x] || app.strings.statistics[x] || x;
-        option.innerHTML = app.Utils.tidyText(text, 80, true);
-        app.Stats.el.stat.appendChild(option);
-      }
+      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if (!app.Goals.showInStats(x)) return;
+
+      let option = document.createElement("option");
+      option.value = x;
+      let text = app.strings.nutriments[x] || app.strings.statistics[x] || x;
+      option.innerHTML = app.Utils.tidyText(text, 50, true);
+      app.Stats.el.stat.appendChild(option);
     });
 
     app.Stats.el.stat.selectedIndex = 0;


### PR DESCRIPTION
A few small simplifications, fixes and improvements after merging the different PR branches.

Also, in case you need a changelog for the next release, here's a summary of the noteworthy changes I made in the different PRs:

- The app now has an Android adaptive icon and an updated splash screen.
- Context menus for copy/paste functionality should be working now.
- All external links now open in an external browser instead of within the app.
- The backup file location has been changed. The new location should be accessible without root on Android 11.
- You can opt to have your goals automatically adjusted during the week to meet the weekly target.
- Goals for fat, carbs and protein can now be set as percentage of energy intake.
- New nutrients have been added: vitamin B3 (niacin), vitamin B5 (pantothenic acid), vitamin B7 (biotin), phosphorus, copper, manganese, fluoride, selenium, iodine.
- The energy/nutrient counts in the diary now stay fixed at the bottom so they're always visible.
- You can see the nutrient subtotals of a diary category by tapping the energy total at the bottom.
- The diary pie chart has been changed again to show macro nutrients with an improved colour palette.
- Below the diary pie chart you now find the percentage of energy intake (for fat, carbs and proteins). There is also a list of all tracked nutrients with their daily totals.
- You can now find the currently installed app version on the About page.