### PR TITLE
Fix missing calories and kilojoules

### DIFF
--- a/www/activities/settings/views/nutriments.html
+++ b/www/activities/settings/views/nutriments.html
@@ -33,6 +33,12 @@
   <div class="page-content">
     <div class="list sortable sortable-tap-hold">
       <ul id="nutriment-list">
+        <li id="calories" class="no-sorting" style="display: none;">
+          Calories
+        </li>
+        <li id="kilojoules" class="no-sorting" style="display: none;">
+          Kilojoules
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Fixes a bug where calories and kilojoules go missing from the `settings.nutriments.order` list when the user rearranges the nutriments in settings.