### PR TITLE
Show average goal in statistics

### DIFF
--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -116,7 +116,7 @@ app.Group = {
 
     //Energy 
     const energyUnit = app.Settings.get("units", "energy");
-    const energyName = Object.keys(app.nutrimentUnits).find(key => app.nutrimentUnits[key] === energyUnit);
+    const energyName = app.Utils.getEnergyUnitName(energyUnit);
 
     let right = document.createElement("div");
     right.className = "margin-horizontal energy link icon-only";

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -86,7 +86,7 @@ app.Goals = {
 
   getGoals: async function(stats, date) {
     const energyUnit = app.Settings.get("units", "energy");
-    const energyName = Object.keys(app.nutrimentUnits).find(key => app.nutrimentUnits[key] === energyUnit);
+    const energyName = app.Utils.getEnergyUnitName(energyUnit);
     const day = date.getDay();
 
     // Check if some goals are defined to auto adjust or defined as percentage of energy

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -191,6 +191,31 @@ app.Goals = {
     return goal;
   },
 
+  getAverageGoal: function(stat) {
+    let goals = app.Settings.get("goals", stat);
+    let averageGoal;
+
+    if (app.Goals.sharedGoal(stat) || app.measurements.includes(stat)) {
+      averageGoal = goals[0];
+    } else {
+      let goalSum = goals.reduce((a, b) => Number(a) + Number(b));
+      averageGoal = goalSum / 7;
+    }
+
+    if (app.Goals.isPercentGoal(stat)) {
+      const energyUnit = app.Settings.get("units", "energy");
+      const energyName = app.Utils.getEnergyUnitName(energyUnit);
+      let averageEnergyGoal = app.Goals.getAverageGoal(energyName);
+
+      if (energyUnit == app.nutrimentUnits.kilojoules)
+        averageEnergyGoal = app.Utils.convertUnit(averageEnergyGoal, app.nutrimentUnits.kilojoules, app.nutrimentUnits.calories);
+
+      averageGoal = app.Goals.getEnergyPercentGoal(stat, averageGoal, averageEnergyGoal);
+    }
+
+    return averageGoal;
+  },
+
   getEnergyPercentGoal: function(stat, percentGoal, energyGoal) {
     let caloriesPerUnit = app.Goals.getMacroNutrimentCalories(stat);
     let result = Math.round(percentGoal / 100 * energyGoal / caloriesPerUnit);

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -288,11 +288,11 @@ app.Stats = {
       }
 
       let title = app.strings.nutriments[field] || app.strings.statistics[field] || field;
-      let goal = await app.Goals.getGoals([field], new Date());
+      let goal = app.Goals.getAverageGoal(field);
 
       result.dataset.label = app.Utils.tidyText(title, 50) + " (" + unitSymbol + ")";
       result.average = result.average / result.dates.length || 0;
-      result.goal = goal[field];
+      result.goal = goal;
 
       resolve(result);
     }).catch(err => {

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -143,6 +143,10 @@ app.Utils = {
     return result;
   },
 
+  getEnergyUnitName: function(energyUnit) {
+    return Object.keys(app.nutrimentUnits).find(key => app.nutrimentUnits[key] === energyUnit);
+  },
+
   writeFile: function(data, filename) {
     return new Promise(function(resolve, reject) {
       if (app.mode !== "development" && device.platform !== "browser") {


### PR DESCRIPTION
At the moment, the goal line on the statistics page always shows the goal for the current day. This is fine, of course, if you use the same goal every day. But it isn't that useful when you have a different goal for each day or when the "auto adjust" setting is enabled. In that case, it would make more sense to show the average of your goals because then you can more easily compare your average consumption (red line) to your average goal (green line).

This PR changes the goal line on the statistics page to show the average goal instead of just the goal for the current day.