### PR TITLE
Food editor improvements

### DIFF
--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -151,8 +151,7 @@ app.OpenFoodFacts = {
       let x = nutriments[i];
       if (x != "calories" && x != "kilojoules") {
         let value = item.nutriments[x + perTag];
-        let unit = item.nutriments[x + "_unit"];
-        result.nutrition[x] = app.Utils.convertUnit(value, unit, units[x]);
+        result.nutrition[x] = app.Utils.convertUnit(value, "g", units[x]);
       }
     }
 

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -427,7 +427,7 @@ app.FoodEditor = {
         for (let k of nutriments) {
           if (k != field) {
             let input = document.querySelector("#food-edit-form #" + k);
-            if (input) {
+            if (input && input.value !== "") {
               input.value = Math.round(input.oldValue * multiplier * 100) / 100 || 0;
             }
           }

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -388,7 +388,8 @@ app.FoodEditor = {
           if (item.image_url !== undefined && item.image_url != "" && item.image_url !== "undefined") {
             let img = document.createElement("img");
             img.src = unescape(item.image_url);
-            img.style["width"] = "50%";
+            img.style["max-width"] = "80vw";
+            img.style["max-height"] = "50vh";
 
             app.FoodEditor.el.mainPhoto.style.display = "block";
             app.FoodEditor.el.mainPhoto.appendChild(img);


### PR DESCRIPTION
This PR includes some improvements for the food editor and fixes a bug in the OFF import.

In the food editor, the food image now has a `max-width` and a `max-height` instead of an explicit `width`. This looks much better, in my opinion. Here are some examples before (left) and after (right):

![arrabbiata1](https://user-images.githubusercontent.com/19289477/140070610-065427bd-7697-4dbd-9f48-c5f35496613d.png) ![arrabbiata2](https://user-images.githubusercontent.com/19289477/140070612-06f3e29a-91c7-4ee2-bfaa-6c0c814c6ac7.png)

A relatively wide image before and after:

![milka1](https://user-images.githubusercontent.com/19289477/140070613-705ecf19-72a0-4d83-9d5e-a0e7f0dce640.png) ![milka2](https://user-images.githubusercontent.com/19289477/140070614-813c1374-4adf-4e36-a07d-8774b7eb1e81.png)

A relatively tall image before and after:

![soja1](https://user-images.githubusercontent.com/19289477/140070616-a1e6c74c-780f-4fc0-9930-777a9f8f0636.png) ![soja2](https://user-images.githubusercontent.com/19289477/140070619-079c25c5-4a5e-4fc5-b788-6641566e8a41.png)
