### PR TITLE
Fix and improve food thumbnails alignment

### DIFF
--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -528,8 +528,7 @@ app.FoodsMealsRecipes = {
         if ((wifiOnly && navigator.connection.type == "wifi") || !wifiOnly) {
           let img = document.createElement("img");
           img.src = unescape(url);
-          img.style.width = "20%";
-          img.style["padding-right"] = "1em";
+          img.className = "food-thumbnail";
 
           return img;
         }

--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -18,6 +18,9 @@ i.searchbar-icon {margin: -12px 12px;}
 #quantity-container .item-title {width:65% !important;}
 #nutrition .item-title {width:65% !important;}
 
+img.food-thumbnail {width: 20%; margin: 0.2em 1em 0.2em 0;}
+html[dir="rtl"] img.food-thumbnail {margin: 0.2em 0 0.2em 1em;}
+
 /* Custom color themes */
 .color-theme-pink {
   --f7-theme-color: #f6b0ba;


### PR DESCRIPTION
Improving the alignment of food thumbnails in the diary, especially for the RTL layout.

This is how it looked before:

![before](https://user-images.githubusercontent.com/19289477/140587306-4d281476-1529-45fd-8834-db816d585a73.png)

And this is how it looks now:

![after](https://user-images.githubusercontent.com/19289477/140587313-d59f64e8-cc0d-43a4-9437-58161b17696b.png)
