### PR TITLE
Add button to re-download imported food item info

### DIFF
--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -70,10 +70,8 @@ app.Foodlist = {
     //Search form 
     app.Foodlist.el.searchForm.addEventListener("submit", (e) => {
       app.Utils.hideKeyboard();
-      if (navigator.connection.type !== "none")
+      if (app.Utils.isInternetConnected())
         this.search(app.Foodlist.el.search.value);
-      else
-        app.Utils.toast(app.strings.dialogs["no-internet"] || "No Internet Connection");
     });
 
     if (!app.Foodlist.el.scan.hasClickEvent) {
@@ -363,24 +361,24 @@ app.Foodlist = {
 
             // Not already in foodlist so search OFF 
             if (item === undefined || (item.archived !== undefined && item.archived == true)) {
-              if (navigator.connection.type == "none") {
-                app.Utils.toast(app.strings.dialogs["no-internet"] || "No Internet Connection");
+
+              if (!app.Utils.isInternetConnected()) {
                 resolve(undefined);
+              } else {
+                // Display loading image
+                app.f7.preloader.show();
+                let result = await app.OpenFoodFacts.search(code);
+                app.f7.preloader.hide();
+
+                // When downloading data for archived items reuse the same id
+                if (item !== undefined && item.id !== undefined)
+                  result[0].id = item.id;
+
+                if (result !== undefined && result[0] !== undefined)
+                  item = result[0];
+                else
+                  app.Foodlist.gotoUploadEditor(code);
               }
-
-              // Display loading image
-              app.f7.preloader.show();
-              let result = await app.OpenFoodFacts.search(code);
-              app.f7.preloader.hide();
-
-              // When downloading data for archived items reuse the same id
-              if (item !== undefined && item.id !== undefined)
-                result[0].id = item.id;
-
-              if (result !== undefined && result[0] !== undefined)
-                item = result[0];
-              else
-                app.Foodlist.gotoUploadEditor(code);
             }
             resolve(item);
           } else {

--- a/www/activities/foods-meals-recipes/views/food-editor.html
+++ b/www/activities/foods-meals-recipes/views/food-editor.html
@@ -30,6 +30,9 @@
         <span id="link" style="display:none;">
           <a href="#" class="link icon-only"><i id="link-icon" class="icon material-icons">link</i></a>
         </span>
+        <span id="download" style="display:none;">
+          <a href="#" class="link icon-only"><i class="icon material-icons">&#xe2c4</i></a>
+        </span>
         <span id="upload" style="display:none;">
           <a href="#" class="link icon-only"><i class="icon material-icons">&#xe2c6</i></a>
         </span>
@@ -147,7 +150,7 @@
                 </div>
               </li>
 
-              <li class="item-content item-input" class="hide-for-upload" id="notes-container">
+              <li class="item-content item-input hide-for-upload" id="notes-container">
                 <div class="item-inner">
                   <div class="item-title item-label" data-localize="food-editor.notes">Notes</div>
                   <div class="item-input-wrap">

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -21,11 +21,10 @@ app.Utils = {
 
   isInternetConnected: function() {
     if (navigator.connection.type == "none") {
-      let msg = app.strings["no-internet"] || "No Internet Connection";
-      app.Utils.notify(msg, "error");
+      let msg = app.strings.dialogs["no-internet"] || "No Internet Connection";
+      app.Utils.toast(msg);
       return false;
     }
-
     return true;
   },
 

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -79,6 +79,8 @@
     "number-of-calories": "Please provide the number of calories for this food.",
     "add-to-off": "Would you like to add this product to the Open Food Facts database?",
     "main-image": "Please add a main image",
+    "download-title": "Retrieve latest information",
+    "download-text": "Your local values will be replaced by the latest information available for this item",
     "upload-success": "Product successfully added to Open Food Facts",
     "upload-failed": "Unfortunately the upload failed. Please try again or contact the developer.",
     "what-meal": "What meal is this?"


### PR DESCRIPTION
This adds a button in the food editor to re-download imported food item information. The button only shows up for items that have a barcode (i.e. items from OFF or USDA) and only when adding or editing them. Pressing it will replace the local values with the latest information available for the item (except for the notes which are preserved).

There are various use cases for this, but the most important one is when you scan the barcode of a product whose OFF entry is incomplete or outdated. In this case, you can simply tap on the barcode to be taken to the OFF website, complete the information there, and then switch back to Waistline and press the button to fetch the changes you just made. This eliminates the need to rescan the barcode and should address #380.

![1](https://user-images.githubusercontent.com/19289477/141613946-e2d801eb-fc89-49f8-9e9a-6131f74c91c0.png)

![2](https://user-images.githubusercontent.com/19289477/141613949-35982a29-36d6-4729-a9a6-dfb19604b127.png)