### PR TITLE
Add food categories and custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Waistline is a libre calorie counter and weight tracker app for Android. It's bu
 
 ### App Features
 
-Features of waistline include:
+Features of Waistline include:
 
 - **Diary**: This is where users can keep a day by day account of the food they eat at different times.
 - **Food List**: This is where users can create a local database of foods. This can be done either by inputting the food details manually, by scanning the barcode of a product, or by searching for the product online. Waistline connects to Open Food Facts and to the USDA food database to find information about products.
@@ -38,7 +38,7 @@ For the software to function efficiently camera and storage permissions are requ
 ### Types of Data Collected
 
 #### Personal Data
-No personal data is collected while utilizing the software
+No personal data is collected while utilizing the software.
 
 #### Usage Data
 Usage data is collected only when interacting with the Open Food Facts or USDA databases.

--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -115,9 +115,11 @@ app.DiaryChart = {
           name += " (" + including + ")";
         }
 
+        let value = (Math.round(percent * 100) / 100) + "%";
+
         let entry = {
           name: app.Utils.tidyText(name, 50),
-          value: (Math.round(percent * 100) / 100) + "%"
+          value: value
         }
         result.macros.push(entry);
       });
@@ -131,9 +133,9 @@ app.DiaryChart = {
         let name = app.strings.nutriments[x] || x;
         let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
 
-        let value = (Math.round(nutrition[x] * 100) / 100)
+        let value = (Math.round(nutrition[x] * 100) / 100);
         if (unit !== undefined)
-          value += " " + unit
+          value += " " + unit;
 
         let entry = {
           name: app.Utils.tidyText(name, 50),

--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -57,8 +57,9 @@ app.DiaryChart = {
     return new Promise(async function(resolve, reject) {
 
       const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+      const customUnits = app.Settings.get("nutriments", "units") || {};
+      const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
       const visible = app.Settings.getField("nutrimentVisibility");
-      const nutrimentUnits = app.nutrimentUnits;
 
       let result = {
         "labels": [],
@@ -128,11 +129,15 @@ app.DiaryChart = {
         if (!nutrition[x]) return;
 
         let name = app.strings.nutriments[x] || x;
-        let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || "g";
+        let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
+
+        let value = (Math.round(nutrition[x] * 100) / 100)
+        if (unit !== undefined)
+          value += " " + unit
 
         let entry = {
           name: app.Utils.tidyText(name, 50),
-          value: (Math.round(nutrition[x] * 100) / 100) + " " + unit
+          value: value
         }
         result.totals.push(entry);
       });

--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -57,8 +57,7 @@ app.DiaryChart = {
     return new Promise(async function(resolve, reject) {
 
       const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-      const customUnits = app.Settings.get("nutriments", "units") || {};
-      const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+      const units = app.Nutriments.getNutrimentUnits();
       const visible = app.Settings.getField("nutrimentVisibility");
 
       let result = {
@@ -131,7 +130,7 @@ app.DiaryChart = {
         if (!nutrition[x]) return;
 
         let name = app.strings.nutriments[x] || x;
-        let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
+        let unit = app.strings["unit-symbols"][units[x]] || units[x];
 
         let value = (Math.round(nutrition[x] * 100) / 100);
         if (unit !== undefined)

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -181,9 +181,11 @@ app.Diary = {
   },
 
   renderNutritionCard: async function(nutrition, date, swiper) {
-    let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    let nutrimentUnits = app.nutrimentUnits;
-    let energyUnit = app.Settings.get("units", "energy");
+    const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    const customUnits = app.Settings.get("nutriments", "units") || {};
+    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+    const energyUnit = app.Settings.get("units", "energy");
+
     let rows = [];
     let count = 0;
 
@@ -268,7 +270,7 @@ app.Diary = {
 
       // Unit
       if (app.Settings.get("diary", "show-nutrition-units")) {
-        let unit = app.strings["unit-symbols"][nutrimentUnits[x]];
+        let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
         if (unit !== undefined)
           t.nodeValue += " " + unit;
       }
@@ -515,11 +517,10 @@ app.Diary = {
 
   quickAdd: function(category) {
     let title = app.strings.diary["quick-add"] || "Quick Add";
-    let units = app.nutrimentUnits;
     let energyUnit = app.Settings.get("units", "energy");
 
     let text;
-    if (energyUnit == units.calories)
+    if (energyUnit == app.nutrimentUnits.calories)
       text = app.strings.nutriments["calories"] || "Calories";
     else
       text = app.strings.nutriments["kilojoules"] || "Kilojoules";
@@ -555,8 +556,8 @@ app.Diary = {
 
             let quantity = Array.from(dialog.el.getElementsByTagName("input"))[0].value;
 
-            if (energyUnit == units.kilojoules)
-              quantity = app.Utils.convertUnit(quantity, units.kilojoules, units.calories);
+            if (energyUnit == app.nutrimentUnits.kilojoules)
+              quantity = app.Utils.convertUnit(quantity, app.nutrimentUnits.kilojoules, app.nutrimentUnits.calories);
 
             if (!isNaN(quantity)) {
               let item = await app.Foodlist.getQuickAddItem(); // Get food item
@@ -710,9 +711,10 @@ app.Diary = {
     const dialogTitle = app.strings.diary["default-meals"][mealName.toLowerCase()] || mealName;
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const visible = app.Settings.getField("nutrimentVisibility");
-    const nutrimentUnits = app.nutrimentUnits;
+    const customUnits = app.Settings.get("nutriments", "units") || {};
+    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
     const energyUnit = app.Settings.get("units", "energy");
+    const visible = app.Settings.getField("nutrimentVisibility");
 
     // Create dialog
     let div = document.createElement("div");
@@ -733,7 +735,7 @@ app.Diary = {
 
       // Get name, unit and value
       let name = app.strings.nutriments[x] || x;
-      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || "g";
+      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
       let value = 0;
 
       if (nutrition !== undefined && nutrition[x] !== undefined) {
@@ -760,7 +762,9 @@ app.Diary = {
       // Value and Unit
       let content = document.createElement("div");
       content.className = "flex-shrink-0";
-      text = value + " " + unit;
+      text = value;
+      if (unit !== undefined)
+        text += " " + unit;
       t = document.createTextNode(text);
       content.appendChild(t);
 

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -699,7 +699,8 @@ app.Diary = {
     window.localStorage.setItem("stats", JSON.stringify(stats));
 
     dbHandler.put(entry, "diary").onsuccess = function(e) {
-      app.Utils.toast("Saved");
+      let msg = app.strings.diary["log-saved"] || "Saved";
+      app.Utils.toast(msg);
     };
   },
 

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -375,7 +375,7 @@ app.Diary = {
 
         // Input fields
         let inputs = document.createElement("form");
-        inputs.className = "list scroll-dialog";
+        inputs.className = "list no-hairlines scroll-dialog";
         let ul = document.createElement("ul");
         inputs.appendChild(ul);
 
@@ -587,7 +587,7 @@ app.Diary = {
 
     // Create dialog inputs
     let inputs = document.createElement("form");
-    inputs.className = "list scroll-dialog";
+    inputs.className = "list no-hairlines scroll-dialog";
 
     let ul = document.createElement("ul");
     inputs.appendChild(ul);

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -182,8 +182,7 @@ app.Diary = {
 
   renderNutritionCard: async function(nutrition, date, swiper) {
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const customUnits = app.Settings.get("nutriments", "units") || {};
-    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+    const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
 
     let rows = [];
@@ -204,7 +203,7 @@ app.Diary = {
     // Determine which nutriments need to be shown and calculate the goals
     nutrimentsToShow = [];
     nutriments.forEach((x) => {
-      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) return;
       if (!app.Goals.showInDiary(x)) return;
       nutrimentsToShow.push(x);
     });
@@ -270,7 +269,7 @@ app.Diary = {
 
       // Unit
       if (app.Settings.get("diary", "show-nutrition-units")) {
-        let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
+        let unit = app.strings["unit-symbols"][units[x]] || units[x];
         if (unit !== undefined)
           t.nodeValue += " " + unit;
       }
@@ -711,8 +710,7 @@ app.Diary = {
     const dialogTitle = app.strings.diary["default-meals"][mealName.toLowerCase()] || mealName;
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const customUnits = app.Settings.get("nutriments", "units") || {};
-    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+    const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
     const visible = app.Settings.getField("nutrimentVisibility");
 
@@ -728,14 +726,14 @@ app.Diary = {
       let x = nutriments[i];
 
       if (x == "calories" || x == "kilojoules") {
-        if (nutrimentUnits[x] != energyUnit) continue;
+        if (units[x] != energyUnit) continue;
       } else {
         if (!visible[x]) continue;
       }
 
       // Get name, unit and value
       let name = app.strings.nutriments[x] || x;
-      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
+      let unit = app.strings["unit-symbols"][units[x]] || units[x];
       let value = 0;
 
       if (nutrition !== undefined && nutrition[x] !== undefined) {

--- a/www/activities/diary/views/diary.css
+++ b/www/activities/diary/views/diary.css
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018, 2019, 2020 David Healey
+  Copyright 2018, 2019, 2020, 2021 David Healey
 
   This file is part of Waistline.
 

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -56,6 +56,9 @@ app.Foodlist = {
     app.Foodlist.el.scan = document.querySelector(".page[data-name='foods-meals-recipes'] #scan");
     app.Foodlist.el.search = document.querySelector("#foods-tab #food-search");
     app.Foodlist.el.searchForm = document.querySelector("#foods-tab #food-search-form");
+    app.Foodlist.el.searchFilter = document.querySelector("#foods-tab #food-search-filter");
+    app.Foodlist.el.searchFilterIcon = document.querySelector("#foods-tab #food-search-filter-icon");
+    app.Foodlist.el.searchFilterContainer = document.querySelector("#foods-tab #food-search-filter-container");
     app.Foodlist.el.infinite = document.querySelector(".page[data-name='foods-meals-recipes'] #foodlist"); //Infinite list container
     app.Foodlist.el.list = document.querySelector(".page[data-name='foods-meals-recipes'] #foodlist ul"); //Infinite list
   },
@@ -228,10 +231,27 @@ app.Foodlist = {
       searchbarSearch: async (searchbar, query, previousQuery) => {
         if (query == "")
           app.Foodlist.filterList = await app.Foodlist.getListFromDB();
-        app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Foodlist.filterList);
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Foodlist.el.searchFilter);
+        app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, categories, app.Foodlist.filterList);
         app.Foodlist.renderList(true);
       },
     });
+    app.FoodsMealsRecipes.populateCategoriesField(app.Foodlist.el.searchFilter, undefined, true, false, {
+      beforeOpen: (smartSelect, prevent) => {
+        smartSelect.selectEl.selectedIndex = -1;
+      },
+      close: (smartSelect) => {
+        let query = app.Foodlist.el.search.value;
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Foodlist.el.searchFilter);
+        if (categories !== undefined)
+          app.Foodlist.el.searchFilterIcon.classList.add(".color-theme");
+        else
+          app.Foodlist.el.searchFilterIcon.classList.remove(".color-theme")
+        app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, categories, app.Foodlist.filterList);
+        app.Foodlist.renderList(true);
+      }
+    });
+    app.FoodsMealsRecipes.setCategoriesVisibility(app.Foodlist.el.searchFilterContainer);
   },
 
   searchByBarcode: function(code) {

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -65,16 +65,23 @@ app.Foodlist = {
 
   bindUIActions: function() {
 
-    //Infinite list 
+    // Infinite list - render more items
     app.Foodlist.el.infinite.addEventListener("infinite", (e) => {
       this.renderList();
     });
 
-    //Search form 
+    // Search form - search online
     app.Foodlist.el.searchForm.addEventListener("submit", (e) => {
       app.Utils.hideKeyboard();
       if (app.Utils.isInternetConnected())
         this.search(app.Foodlist.el.search.value);
+    });
+
+    // Search filter - reset category filter on long press
+    app.Foodlist.el.searchFilter.addEventListener("taphold", async (e) => {
+      app.FoodsMealsRecipes.clearSelectedCategories(app.Foodlist.el.searchFilter, app.Foodlist.el.searchFilterIcon);
+      app.Foodlist.list = app.FoodsMealsRecipes.filterList(app.Foodlist.el.search.value, undefined, app.Foodlist.filterList);
+      app.Foodlist.renderList(true);
     });
 
     if (!app.Foodlist.el.scan.hasClickEvent) {
@@ -235,12 +242,6 @@ app.Foodlist = {
           app.Foodlist.filterList = await app.Foodlist.getListFromDB();
         let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Foodlist.el.searchFilter);
         app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, categories, app.Foodlist.filterList);
-        app.Foodlist.renderList(true);
-      },
-      searchbarDisable: async (searchbar) => {
-        app.FoodsMealsRecipes.clearSelectedCategories(app.Foodlist.el.searchFilter, app.Foodlist.el.searchFilterIcon);
-        app.Foodlist.filterList = await app.Foodlist.getListFromDB();
-        app.Foodlist.list = app.Foodlist.filterList;
         app.Foodlist.renderList(true);
       }
     });

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -237,6 +237,12 @@ app.Foodlist = {
         app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, categories, app.Foodlist.filterList);
         app.Foodlist.renderList(true);
       },
+      searchbarDisable: async (searchbar) => {
+        app.FoodsMealsRecipes.clearSelectedCategories(app.Foodlist.el.searchFilter, app.Foodlist.el.searchFilterIcon);
+        app.Foodlist.filterList = await app.Foodlist.getListFromDB();
+        app.Foodlist.list = app.Foodlist.filterList;
+        app.Foodlist.renderList(true);
+      }
     });
     app.FoodsMealsRecipes.populateCategoriesField(app.Foodlist.el.searchFilter, undefined, true, false, {
       beforeOpen: (smartSelect, prevent) => {
@@ -248,7 +254,7 @@ app.Foodlist = {
         if (categories !== undefined)
           app.Foodlist.el.searchFilterIcon.classList.add(".color-theme");
         else
-          app.Foodlist.el.searchFilterIcon.classList.remove(".color-theme")
+          app.Foodlist.el.searchFilterIcon.classList.remove(".color-theme");
         app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, categories, app.Foodlist.filterList);
         app.Foodlist.renderList(true);
       }

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -224,18 +224,13 @@ app.Foodlist = {
   },
 
   createSearchBar: function() {
-    const searchBar = app.f7.searchbar.create({
-      el: app.Foodlist.el.searchForm,
-      backdrop: false,
-      customSearch: true,
-      on: {
-        async search(searchbar, query, previousQuery) {
-          if (query == "")
-            app.Foodlist.filterList = await app.Foodlist.getListFromDB();
-          app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Foodlist.filterList);
-          app.Foodlist.renderList(true);
-        },
-      }
+    app.FoodsMealsRecipes.initializeSearchBar(app.Foodlist.el.searchForm, {
+      searchbarSearch: async (searchbar, query, previousQuery) => {
+        if (query == "")
+          app.Foodlist.filterList = await app.Foodlist.getListFromDB();
+        app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Foodlist.filterList);
+        app.Foodlist.renderList(true);
+      },
     });
   },
 

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -229,14 +229,10 @@ app.Foodlist = {
       backdrop: false,
       customSearch: true,
       on: {
-        async search(sb, query, previousQuery) {
-          if (query != "") {
-            app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, app.Foodlist.filterList);
-            app.Foodlist.renderList(true);
-          } else {
-            app.Foodlist.list = await app.Foodlist.getListFromDB();
-            app.Foodlist.filterList = app.Foodlist.list;
-          }
+        async search(searchbar, query, previousQuery) {
+          if (query == "")
+            app.Foodlist.filterList = await app.Foodlist.getListFromDB();
+          app.Foodlist.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Foodlist.filterList);
           app.Foodlist.renderList(true);
         },
       }

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -120,7 +120,7 @@ app.Foodlist = {
         }
       } else {
         let msg = app.strings.dialogs["no-search-providers"] || "No search providers are enabled";
-        app.Utils.toast(msg, 2000);
+        app.Utils.toast(msg);
       }
     }
 

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -93,6 +93,8 @@ app.Foodlist = {
     if (query != "") {
       app.f7.preloader.show();
 
+      app.FoodsMealsRecipes.clearSelectedCategories(app.Foodlist.el.searchFilter, app.Foodlist.el.searchFilterIcon);
+
       let offList = [];
       let usdaList = [];
 

--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -107,7 +107,7 @@ app.OpenFoodFacts = {
     if (item.serving_size) {
       result.portion = parseInt(item.serving_size);
       let itemUnit = item.serving_size.replace(/ *\([^)]*\) */g, "").replace(/[^a-z]+|\s+/gmi, "");
-      result.unit = app.strings["unit-symbols"][itemUnit] || itemUnit;
+      result.unit = app.strings["unit-symbols"][itemUnit.toLowerCase()] || itemUnit;
       if (item.nutriments.energy_serving) {
         result.nutrition.calories = (item.nutriments["energy-kcal_serving"]) ?
           parseInt(item.nutriments["energy-kcal_serving"]) :

--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -80,7 +80,7 @@ app.OpenFoodFacts = {
 
   parseItem: function(item) {
     const nutriments = app.nutriments; // Array of OFF nutriment names
-    const nutrimentUnits = app.nutrimentUnits;
+    const units = app.nutrimentUnits;
 
     let result = {
       "nutrition": {}
@@ -114,13 +114,13 @@ app.OpenFoodFacts = {
       if (item.nutriments.energy_serving !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_serving"]) ?
           parseInt(item.nutriments["energy-kcal_serving"]) :
-          app.Utils.convertUnit(item.nutriments.energy_serving, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_serving, units.kilojoules, units.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_serving;
         perTag = "_serving";
       } else if (item.nutriments.energy_prepared_serving !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_prepared_serving"]) ?
           parseInt(item.nutriments["energy-kcal_prepared_serving"]) :
-          app.Utils.convertUnit(item.nutriments.energy_prepared_serving, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_prepared_serving, units.kilojoules, units.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_prepared_serving;
         perTag = "_prepared_serving";
       }
@@ -130,13 +130,13 @@ app.OpenFoodFacts = {
       if (item.nutriments.energy_100g !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_100g"]) ?
           item.nutriments["energy-kcal_100g"] :
-          app.Utils.convertUnit(item.nutriments.energy_100g, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_100g, units.kilojoules, units.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_100g;
         perTag = "_100g";
       } else if (item.nutriments.energy_prepared_100g !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_prepared_100g"]) ?
           item.nutriments["energy-kcal_prepared_100g"] :
-          app.Utils.convertUnit(item.nutriments.energy_prepared_100g, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_prepared_100g, units.kilojoules, units.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_prepared_100g;
         perTag = "_prepared_100g";
       }
@@ -154,7 +154,7 @@ app.OpenFoodFacts = {
       let x = nutriments[i];
       if (x != "calories" && x != "kilojoules") {
         let value = item.nutriments[x + perTag];
-        result.nutrition[x] = app.Utils.convertUnit(value, "g", nutrimentUnits[x]);
+        result.nutrition[x] = app.Utils.convertUnit(value, "g", units[x]);
       }
     }
 
@@ -217,7 +217,7 @@ app.OpenFoodFacts = {
 
   getUploadString: function(data) {
     const nutriments = app.nutriments; // Array of OFF nutriment names
-    const nutrimentUnits = app.nutrimentUnits;
+    const units = app.nutrimentUnits;
 
     let string = "";
 
@@ -236,9 +236,9 @@ app.OpenFoodFacts = {
 
     // Energy
     if (data.nutrition.calories !== undefined && data.nutrition.kilojoules == undefined)
-      data.nutrition.kilojoules = app.Utils.convertUnit(data.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules, true);
+      data.nutrition.kilojoules = app.Utils.convertUnit(data.nutrition.calories, units.calories, units.kilojoules, true);
     else if (data.nutrition.calories == undefined && data.nutrition.kilojoules !== undefined)
-      data.nutrition.calories = app.Utils.convertUnit(data.nutrition.kilojoules, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
+      data.nutrition.calories = app.Utils.convertUnit(data.nutrition.kilojoules, units.kilojoules, units.calories, true);
 
     data.nutrition["energy-kcal"] = data.nutrition.calories;
     data.nutrition["energy-kj"] = data.nutrition.kilojoules;

--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -80,7 +80,7 @@ app.OpenFoodFacts = {
 
   parseItem: function(item) {
     const nutriments = app.nutriments; // Array of OFF nutriment names
-    const units = app.nutrimentUnits;
+    const nutrimentUnits = app.nutrimentUnits;
 
     let result = {
       "nutrition": {}
@@ -114,13 +114,13 @@ app.OpenFoodFacts = {
       if (item.nutriments.energy_serving !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_serving"]) ?
           parseInt(item.nutriments["energy-kcal_serving"]) :
-          app.Utils.convertUnit(item.nutriments.energy_serving, units.kilojoules, units.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_serving, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_serving;
         perTag = "_serving";
       } else if (item.nutriments.energy_prepared_serving !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_prepared_serving"]) ?
           parseInt(item.nutriments["energy-kcal_prepared_serving"]) :
-          app.Utils.convertUnit(item.nutriments.energy_prepared_serving, units.kilojoules, units.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_prepared_serving, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_prepared_serving;
         perTag = "_prepared_serving";
       }
@@ -130,13 +130,13 @@ app.OpenFoodFacts = {
       if (item.nutriments.energy_100g !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_100g"]) ?
           item.nutriments["energy-kcal_100g"] :
-          app.Utils.convertUnit(item.nutriments.energy_100g, units.kilojoules, units.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_100g, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_100g;
         perTag = "_100g";
       } else if (item.nutriments.energy_prepared_100g !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_prepared_100g"]) ?
           item.nutriments["energy-kcal_prepared_100g"] :
-          app.Utils.convertUnit(item.nutriments.energy_prepared_100g, units.kilojoules, units.calories, true);
+          app.Utils.convertUnit(item.nutriments.energy_prepared_100g, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_prepared_100g;
         perTag = "_prepared_100g";
       }
@@ -154,7 +154,7 @@ app.OpenFoodFacts = {
       let x = nutriments[i];
       if (x != "calories" && x != "kilojoules") {
         let value = item.nutriments[x + perTag];
-        result.nutrition[x] = app.Utils.convertUnit(value, "g", units[x]);
+        result.nutrition[x] = app.Utils.convertUnit(value, "g", nutrimentUnits[x]);
       }
     }
 
@@ -216,7 +216,8 @@ app.OpenFoodFacts = {
   },
 
   getUploadString: function(data) {
-    const units = app.nutrimentUnits;
+    const nutriments = app.nutriments; // Array of OFF nutriment names
+    const nutrimentUnits = app.nutrimentUnits;
 
     let string = "";
 
@@ -235,9 +236,9 @@ app.OpenFoodFacts = {
 
     // Energy
     if (data.nutrition.calories !== undefined && data.nutrition.kilojoules == undefined)
-      data.nutrition.kilojoules = app.Utils.convertUnit(data.nutrition.calories, units.calories, units.kilojoules, true);
+      data.nutrition.kilojoules = app.Utils.convertUnit(data.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules, true);
     else if (data.nutrition.calories == undefined && data.nutrition.kilojoules !== undefined)
-      data.nutrition.calories = app.Utils.convertUnit(data.nutrition.kilojoules, units.kilojoules, units.calories, true);
+      data.nutrition.calories = app.Utils.convertUnit(data.nutrition.kilojoules, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
 
     data.nutrition["energy-kcal"] = data.nutrition.calories;
     data.nutrition["energy-kj"] = data.nutrition.kilojoules;
@@ -245,6 +246,7 @@ app.OpenFoodFacts = {
     // Nutrition
     for (let n in data.nutrition) {
       if (data.nutrition[n] == 0 || n == "kilojoules" || n == "calories") continue;
+      if (!nutriments.includes(n)) continue;
 
       if (data.nutrition_per == "&nutrition_data_per=100g")
         string += "&nutriment_" + n + "_100g=" + data.nutrition[n];

--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -94,6 +94,9 @@ app.OpenFoodFacts = {
       }
     }
 
+    if (result.name == undefined || result.name == "")
+      result.name = item.code;
+
     result.image_url = escape(item.image_url);
     result.barcode = item.code;
 
@@ -108,13 +111,13 @@ app.OpenFoodFacts = {
       result.portion = parseInt(item.serving_size);
       let itemUnit = item.serving_size.replace(/ *\([^)]*\) */g, "").replace(/[^a-z]+|\s+/gmi, "");
       result.unit = app.strings["unit-symbols"][itemUnit.toLowerCase()] || itemUnit;
-      if (item.nutriments.energy_serving) {
+      if (item.nutriments.energy_serving !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_serving"]) ?
           parseInt(item.nutriments["energy-kcal_serving"]) :
           app.Utils.convertUnit(item.nutriments.energy_serving, units.kilojoules, units.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_serving;
         perTag = "_serving";
-      } else if (item.nutriments.energy_prepared_serving) {
+      } else if (item.nutriments.energy_prepared_serving !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_prepared_serving"]) ?
           parseInt(item.nutriments["energy-kcal_prepared_serving"]) :
           app.Utils.convertUnit(item.nutriments.energy_prepared_serving, units.kilojoules, units.calories, true);
@@ -124,13 +127,13 @@ app.OpenFoodFacts = {
     } else if (item.nutrition_data_per == "100g") {
       result.portion = "100";
       result.unit = app.strings["unit-symbols"]["g"] || "g";
-      if (item.nutriments.energy_100g) {
+      if (item.nutriments.energy_100g !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_100g"]) ?
           item.nutriments["energy-kcal_100g"] :
           app.Utils.convertUnit(item.nutriments.energy_100g, units.kilojoules, units.calories, true);
         result.nutrition.kilojoules = item.nutriments.energy_100g;
         perTag = "_100g";
-      } else if (item.nutriments.energy_prepared_100g) {
+      } else if (item.nutriments.energy_prepared_100g !== undefined) {
         result.nutrition.calories = (item.nutriments["energy-kcal_prepared_100g"]) ?
           item.nutriments["energy-kcal_prepared_100g"] :
           app.Utils.convertUnit(item.nutriments.energy_prepared_100g, units.kilojoules, units.calories, true);
@@ -155,7 +158,7 @@ app.OpenFoodFacts = {
       }
     }
 
-    if (result.name == "" || result.nutrition.calories == undefined || result.portion === undefined)
+    if (result.portion == undefined)
       result = undefined;
 
     return result;

--- a/www/activities/foodlist/js/usda.js
+++ b/www/activities/foodlist/js/usda.js
@@ -93,9 +93,9 @@ app.USDA = {
 
   parseItem: function(item) {
 
-    const offNutriments = app.nutriments; //Array of OFF nutriment names
-    const usdaNutriments = app.USDA.nutriments; //Array of USDA nutriment names
-    const units = app.nutrimentUnits;
+    const offNutriments = app.nutriments; // Array of OFF nutriment names
+    const usdaNutriments = app.USDA.nutriments; // Mapping of USDA nutriment names
+    const nutrimentUnits = app.nutrimentUnits;
 
     let result = {
       "nutrition": {}
@@ -110,7 +110,7 @@ app.USDA = {
     //Energy     
     for (let n of item.foodNutrients) {
       if (n.nutrientName == "Energy") {
-        if (n.unitName.toLowerCase() == units.calories)
+        if (n.unitName.toLowerCase() == nutrimentUnits.calories)
           result.nutrition.calories = Math.round(n.value);
         else
           result.nutrition.kilojoules = Math.round(n.value);
@@ -120,10 +120,10 @@ app.USDA = {
     if (result.nutrition.calories || result.nutrition.kilojoules) {
 
       if (result.nutrition.calories == undefined)
-        result.nutrition.calories = app.Utils.convertUnit(result.nutrition.kilojoules, units.kilojoules, units.calories, true);
+        result.nutrition.calories = app.Utils.convertUnit(result.nutrition.kilojoules, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
 
       if (result.nutrition.kilojoules == undefined)
-        result.nutrition.kilojoules = app.Utils.convertUnit(result.nutrition.calories, units.calories, units.kilojoules, true);
+        result.nutrition.kilojoules = app.Utils.convertUnit(result.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules, true);
 
       // Nutriments
       offNutriments.forEach((x, i) => {
@@ -135,7 +135,7 @@ app.USDA = {
 
             if (n.nutrientName.includes(nutriment)) {
 
-              result.nutrition[x] = app.Utils.convertUnit(n.value, n.unitName, units[x]);
+              result.nutrition[x] = app.Utils.convertUnit(n.value, n.unitName, nutrimentUnits[x]);
 
               if (x == "sodium")
                 result.nutrition.salt = result.nutrition.sodium * 0.0025;

--- a/www/activities/foodlist/js/usda.js
+++ b/www/activities/foodlist/js/usda.js
@@ -95,7 +95,7 @@ app.USDA = {
 
     const offNutriments = app.nutriments; // Array of OFF nutriment names
     const usdaNutriments = app.USDA.nutriments; // Mapping of USDA nutriment names
-    const nutrimentUnits = app.nutrimentUnits;
+    const units = app.nutrimentUnits;
 
     let result = {
       "nutrition": {}
@@ -110,7 +110,7 @@ app.USDA = {
     //Energy     
     for (let n of item.foodNutrients) {
       if (n.nutrientName == "Energy") {
-        if (n.unitName.toLowerCase() == nutrimentUnits.calories)
+        if (n.unitName.toLowerCase() == units.calories)
           result.nutrition.calories = Math.round(n.value);
         else
           result.nutrition.kilojoules = Math.round(n.value);
@@ -120,10 +120,10 @@ app.USDA = {
     if (result.nutrition.calories || result.nutrition.kilojoules) {
 
       if (result.nutrition.calories == undefined)
-        result.nutrition.calories = app.Utils.convertUnit(result.nutrition.kilojoules, nutrimentUnits.kilojoules, nutrimentUnits.calories, true);
+        result.nutrition.calories = app.Utils.convertUnit(result.nutrition.kilojoules, units.kilojoules, units.calories, true);
 
       if (result.nutrition.kilojoules == undefined)
-        result.nutrition.kilojoules = app.Utils.convertUnit(result.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules, true);
+        result.nutrition.kilojoules = app.Utils.convertUnit(result.nutrition.calories, units.calories, units.kilojoules, true);
 
       // Nutriments
       offNutriments.forEach((x, i) => {
@@ -135,7 +135,7 @@ app.USDA = {
 
             if (n.nutrientName.includes(nutriment)) {
 
-              result.nutrition[x] = app.Utils.convertUnit(n.value, n.unitName, nutrimentUnits[x]);
+              result.nutrition[x] = app.Utils.convertUnit(n.value, n.unitName, units[x]);
 
               if (x == "sodium")
                 result.nutrition.salt = result.nutrition.sodium * 0.0025;

--- a/www/activities/foodlist/views/foodlist.html
+++ b/www/activities/foodlist/views/foodlist.html
@@ -27,6 +27,16 @@
         <i class="searchbar-icon"></i>
       </div>
       <span class="searchbar-disable-button">Cancel</span>
+      <div slot="inner-end" id="food-search-filter-container">
+        <a id="food-search-filter">
+          <div class="item-inner"></div>
+          <div class="item-content">
+            <div class="margin-horizontal">
+              <i class="icon fas fa-filter" id="food-search-filter-icon"></i>
+            </div>
+          </div>
+        </a>
+      </div>
     </div>
   </form>
 

--- a/www/activities/foodlist/views/foodlist.html
+++ b/www/activities/foodlist/views/foodlist.html
@@ -28,7 +28,6 @@
       </div>
       <span class="searchbar-disable-button">Cancel</span>
     </div>
-
   </form>
 
   <div class="list media-list" id="foodlist-container">

--- a/www/activities/foodlist/views/foodlist.html
+++ b/www/activities/foodlist/views/foodlist.html
@@ -30,10 +30,8 @@
       <div slot="inner-end" id="food-search-filter-container">
         <a id="food-search-filter">
           <div class="item-inner"></div>
-          <div class="item-content">
-            <div class="margin-horizontal">
-              <i class="icon fas fa-filter" id="food-search-filter-icon"></i>
-            </div>
+          <div class="margin-horizontal">
+            <i class="icon fas fa-filter" id="food-search-filter-icon"></i>
           </div>
         </a>
       </div>

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -414,18 +414,20 @@ app.FoodEditor = {
       let oldValue;
 
       if (field == "portion" || field == "quantity")
-        oldValue = item[field];
+        oldValue = app.FoodEditor.el[field].oldValue;
       else
         oldValue = document.querySelector("#food-edit-form #" + field).oldValue;
 
       if (oldValue > 0 && newValue > 0) {
+        let oldQuantity = app.FoodEditor.el.quantity.oldValue;
         let newQuantity = app.FoodEditor.el.quantity.value;
 
         if (field == "portion" || field == "quantity") {
+          let oldPortion = app.FoodEditor.el.portion.oldValue;
           let newPortion = app.FoodEditor.el.portion.value;
-          multiplier = (newPortion / item.portion) * (newQuantity / (item.quantity || 1));
+          multiplier = (newPortion / oldPortion) * (newQuantity / (oldQuantity || 1));
         } else {
-          multiplier = (newValue / oldValue) / (newQuantity / (item.quantity || 1));
+          multiplier = (newValue / oldValue) / (newQuantity / (oldQuantity || 1));
           app.FoodEditor.el.portion.value = Math.round(item.portion * multiplier * 100) / 100;
         }
 

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -180,6 +180,8 @@ app.FoodEditor = {
       }
     }
 
+    app.FoodsMealsRecipes.setCategoriesVisibility(app.FoodEditor.el.categoriesContainer);
+
     if (app.Settings.get("foodlist", "show-notes") == true)
       app.FoodEditor.el.notesContainer.style.display = "block";
     else

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -575,6 +575,10 @@ app.FoodEditor = {
             }
           }
         }
+
+        let categories = app.FoodsMealsRecipes.getSelectedCategories();
+        if (categories !== undefined)
+          item.categories = categories;
       }
 
       return item;

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -20,6 +20,7 @@
 app.FoodEditor = {
 
   item: undefined,
+  item_image_url: undefined,
   scan: false,
   origin: undefined,
   linked: true,
@@ -193,9 +194,7 @@ app.FoodEditor = {
     let fields = Array.from(document.getElementsByClassName("upload-field"));
 
     fields.forEach((x) => {
-      if (app.FoodEditor.scan == true) {
-        x.style.display = "block";
-      } else {
+      if (app.FoodEditor.scan != true) {
         x.style.display = "none";
         x.required = false;
         x.validate = false;
@@ -209,8 +208,6 @@ app.FoodEditor = {
         x.style.display = "none";
         x.required = false;
         x.validate = false;
-      } else {
-        x.style.display = "block";
       }
     });
 
@@ -539,10 +536,10 @@ app.FoodEditor = {
         if (data !== undefined && data.barcode !== undefined)
           item.barcode = data.barcode;
 
-        if (app.FoodEditor.scan == false)
-          item.unit = app.FoodEditor.el.unit.value;
-        else
+        if (app.FoodEditor.scan == true)
           item.unit = app.FoodEditor.el.uploadUnit.value;
+        else
+          item.unit = app.FoodEditor.el.unit.value;
 
         if (app.FoodEditor.item_image_url !== undefined)
           item.image_url = app.FoodEditor.item_image_url;

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -58,7 +58,7 @@ app.FoodEditor = {
     this.setLinkButtonIcon();
 
     const categoriesEditable = (app.FoodEditor.origin == "foodlist");
-    app.FoodsMealsRecipes.populateCategoriesField(app.FoodEditor.el.categories, app.FoodEditor.item, categoriesEditable);
+    app.FoodsMealsRecipes.populateCategoriesField(app.FoodEditor.el.categories, app.FoodEditor.item, categoriesEditable, true);
 
     if (app.FoodEditor.item) {
       this.populateFields(app.FoodEditor.item);

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -467,7 +467,7 @@ app.FoodEditor = {
       (err) => {
         if (err != "No Image Selected") {
           let msg = app.strings.dialogs["camera-problem"] || "There was a problem accessing your camera.";
-          app.Utils.toast(msg, 2000);
+          app.Utils.toast(msg, 2500);
           console.error(err);
         }
       }, options);

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -29,6 +29,7 @@ app.FoodEditor = {
   init: function(context) {
 
     app.FoodEditor.item = undefined;
+    app.FoodEditor.item_image_url = undefined;
     app.FoodEditor.scan = false;
     app.FoodEditor.images = [];
 
@@ -382,6 +383,7 @@ app.FoodEditor = {
   },
 
   populateImage: function(item) {
+    app.FoodEditor.item_image_url = item.image_url;
     app.FoodEditor.el.mainPhoto.innerHTML = "";
 
     if (app.Settings.get("foodlist", "show-images")) {
@@ -540,8 +542,8 @@ app.FoodEditor = {
         else
           item.unit = app.FoodEditor.el.uploadUnit.value;
 
-        if (data !== undefined && data.image_url !== undefined)
-          item.image_url = data.image_url;
+        if (app.FoodEditor.item_image_url !== undefined)
+          item.image_url = app.FoodEditor.item_image_url;
 
         item.nutrition = {};
 

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -57,6 +57,9 @@ app.FoodEditor = {
     this.setRequiredFieldErrorMessage();
     this.setLinkButtonIcon();
 
+    const categoriesEditable = (app.FoodEditor.origin == "foodlist");
+    app.FoodsMealsRecipes.populateCategoriesField(app.FoodEditor.el.categories, app.FoodEditor.item, categoriesEditable);
+
     if (app.FoodEditor.item) {
       this.populateFields(app.FoodEditor.item);
       this.populateImage(app.FoodEditor.item);
@@ -78,6 +81,8 @@ app.FoodEditor = {
     app.FoodEditor.el.submit = document.querySelector(".page[data-name='food-editor'] #submit");
     app.FoodEditor.el.barcodeContainer = document.querySelector(".page[data-name='food-editor'] #barcode-container");
     app.FoodEditor.el.barcode = document.querySelector(".page[data-name='food-editor'] #barcode");
+    app.FoodEditor.el.categoriesContainer = document.querySelector(".page[data-name='food-editor'] #categories-container");
+    app.FoodEditor.el.categories = document.querySelector(".page[data-name='food-editor'] #categories");
     app.FoodEditor.el.name = document.querySelector(".page[data-name='food-editor'] #name");
     app.FoodEditor.el.brand = document.querySelector(".page[data-name='food-editor'] #brand");
     app.FoodEditor.el.categoryContainer = document.querySelector(".page[data-name='food-editor'] #category-container");
@@ -160,6 +165,10 @@ app.FoodEditor = {
       app.FoodEditor.el.unit.style.color = "grey";
       app.FoodEditor.el.notes.disabled = true;
       app.FoodEditor.el.notes.style.color = "grey";
+
+      if (app.Settings.get("foodlist", "show-category-labels") !== true)
+        app.FoodEditor.el.categoriesContainer.style.display = "none";
+
     } else {
       app.FoodEditor.el.quantityContainer.style.display = "none";
 

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -576,7 +576,7 @@ app.FoodEditor = {
           }
         }
 
-        let categories = app.FoodsMealsRecipes.getSelectedCategories();
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.FoodEditor.el.categories);
         if (categories !== undefined)
           item.categories = categories;
       }

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -266,13 +266,12 @@ app.FoodEditor = {
   renderNutritionFields: function(item) {
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const customUnits = app.Settings.get("nutriments", "units") || {};
-    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+    const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
     const visible = app.Settings.getField("nutrimentVisibility");
 
     if (item !== undefined && item.nutrition.kilojoules == undefined)
-      item.nutrition.kilojoules = app.Utils.convertUnit(item.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules);
+      item.nutrition.kilojoules = app.Utils.convertUnit(item.nutrition.calories, units.calories, units.kilojoules);
 
     let ul = app.FoodEditor.el.nutrition;
     ul.innerHTML = ""; //Clear old form 
@@ -284,9 +283,9 @@ app.FoodEditor = {
         li.className = "item-content item-input";
 
         let name = app.strings.nutriments[k] || k;
-        let unit = app.strings["unit-symbols"][nutrimentUnits[k]] || nutrimentUnits[k];
+        let unit = app.strings["unit-symbols"][units[k]] || units[k];
 
-        if (visible[k] !== true && nutrimentUnits[k] !== energyUnit)
+        if (visible[k] !== true && units[k] !== energyUnit)
           li.style.display = "none";
 
         ul.appendChild(li);
@@ -542,7 +541,7 @@ app.FoodEditor = {
 
       if (origin == "foodlist") {
         const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-        const nutrimentUnits = app.nutrimentUnits;
+        const units = app.Nutriments.getNutrimentUnits();
         const energyUnit = app.Settings.get("units", "energy");
         const inputs = document.querySelectorAll("#food-edit-form input:not(#quantity), #food-edit-form textarea, #food-edit-form radio");
         const caloriesEl = document.getElementById("calories");
@@ -562,8 +561,8 @@ app.FoodEditor = {
         item.nutrition = {};
 
         // Always store a calorie value
-        if (energyUnit == nutrimentUnits.kilojoules)
-          caloriesEl.value = app.Utils.convertUnit(kilojoulesEl.value, nutrimentUnits.kilojoules, nutrimentUnits.calories);
+        if (energyUnit == units.kilojoules)
+          caloriesEl.value = app.Utils.convertUnit(kilojoulesEl.value, units.kilojoules, units.calories);
 
         for (let i = 0; i < inputs.length; i++) {
           let x = inputs[i];

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -468,8 +468,12 @@ app.FoodsMealsRecipes = {
           title.innerHTML = app.strings.diary["quick-add"] || "Quick Add";
         } else {
           let text = "";
-          if (item.categories !== undefined && app.Settings.get("foodlist", "show-category-labels") == true)
-            text += item.categories.join("") + " ";
+          if (item.categories !== undefined && app.Settings.get("foodlist", "show-category-labels") == true) {
+            const labels = app.Settings.get("foodlist", "labels");
+            text += labels.filter((label) => {
+              return item.categories.includes(label);
+            }).join("") + " ";
+          }
           text += item.name;
           title.innerHTML = app.Utils.tidyText(text, 50);
         }

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -464,10 +464,15 @@ app.FoodsMealsRecipes = {
         //Title
         let title = document.createElement("div");
         title.className = "item-title";
-        if (item.name === "Quick Add")
+        if (item.name == "Quick Add") {
           title.innerHTML = app.strings.diary["quick-add"] || "Quick Add";
-        else
-          title.innerHTML = app.Utils.tidyText(item.name, 50);
+        } else {
+          let text = "";
+          if (item.categories !== undefined && app.Settings.get("foodlist", "show-category-labels") == true)
+            text += item.categories.join("") + " ";
+          text += item.name;
+          title.innerHTML = app.Utils.tidyText(text, 50);
+        }
         row.appendChild(title);
 
         //Energy

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -609,11 +609,11 @@ app.FoodsMealsRecipes = {
     return app.FoodsMealsRecipes.selection;
   },
 
-  populateCategoriesField: function(element, item, categoriesEditable) {
+  populateCategoriesField: function(element, item, enablePicker, enableRipple, pickerEventHandlers) {
     const labels = app.Settings.get("foodlist", "labels") || [];
     const categories = app.Settings.get("foodlist", "categories") || {};
 
-    if (categoriesEditable) {
+    if (enablePicker) {
       let select = document.createElement("select");
       select.setAttribute("multiple", "");
       element.firstElementChild.append(select);
@@ -628,11 +628,15 @@ app.FoodsMealsRecipes = {
         select.append(option);
       });
 
-      element.className = "item-link smart-select";
-  
+      if (enableRipple)
+        element.className = "item-link smart-select";
+      else
+        element.className = "item-link no-ripple smart-select";
+
       app.f7.smartSelect.create({
         el: element,
-        openIn: "popover"
+        openIn: "popover",
+        on: pickerEventHandlers
       });
     } else {
       let field = element.querySelector("#categories-list");

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -212,7 +212,7 @@ app.FoodsMealsRecipes = {
         data.push(match);
       });
 
-      const units = app.nutrimentUnits;
+      const nutrimentUnits = app.nutrimentUnits;
       if (data.length > 0) {
         // Sum item nutrition
         data.forEach((x, i) => {
@@ -226,7 +226,7 @@ app.FoodsMealsRecipes = {
               result[n] = result[n] || 0;
               result[n] += Math.round(x.nutrition[n] * multiplier * 100) / 100;
               if (n === "calories" && x.nutrition["kilojoules"] === undefined) {
-                let kilojoules = app.Utils.convertUnit(x.nutrition.calories, units.calories, units.kilojoules);
+                let kilojoules = app.Utils.convertUnit(x.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules);
                 result["kilojoules"] = result["kilojoules"] || 0;
                 result["kilojoules"] += Math.round(kilojoules * multiplier * 100) / 100;
               }
@@ -234,7 +234,7 @@ app.FoodsMealsRecipes = {
           }
         });
       }
-      
+
       resolve(result);
     });
   },
@@ -381,11 +381,11 @@ app.FoodsMealsRecipes = {
     let energy = nutrition.calories;
 
     if (energy !== undefined && !isNaN(energy)) {
-      const units = app.nutrimentUnits;
+      const nutrimentUnits = app.nutrimentUnits;
       const energyUnit = app.Settings.get("units", "energy");
 
-      if (energyUnit == units.kilojoules)
-        energy = nutrition.kilojoules || app.Utils.convertUnit(energy, units.calories, units.kilojoules);
+      if (energyUnit == nutrimentUnits.kilojoules)
+        energy = nutrition.kilojoules || app.Utils.convertUnit(energy, nutrimentUnits.calories, nutrimentUnits.kilojoules);
 
       return energy;
     }

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -469,7 +469,7 @@ app.FoodsMealsRecipes = {
         } else {
           let text = "";
           if (item.categories !== undefined && app.Settings.get("foodlist", "show-category-labels") == true) {
-            const labels = app.Settings.get("foodlist", "labels");
+            const labels = app.Settings.get("foodlist", "labels") || [];
             text += labels.filter((label) => {
               return item.categories.includes(label);
             }).join("") + " ";
@@ -610,8 +610,8 @@ app.FoodsMealsRecipes = {
   },
 
   populateCategoriesField: function(element, item, categoriesEditable) {
-    const labels = app.Settings.get("foodlist", "labels");
-    const categories = app.Settings.get("foodlist", "categories");
+    const labels = app.Settings.get("foodlist", "labels") || [];
+    const categories = app.Settings.get("foodlist", "categories") || {};
 
     if (categoriesEditable) {
       let select = document.createElement("select");
@@ -649,6 +649,12 @@ app.FoodsMealsRecipes = {
     if (categories.length > 0)
       return categories;
     return undefined;
+  },
+
+  setCategoriesVisibility: function(container) {
+    const labels = app.Settings.get("foodlist", "labels") || [];
+    if (labels.length == 0)
+      container.style.display = "none";
   },
 
   gotoEditor: function(item) {

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -680,6 +680,12 @@ app.FoodsMealsRecipes = {
     return undefined;
   },
 
+  clearSelectedCategories: function(element, filterIcon) {
+    let smartSelect = app.f7.smartSelect.get(element);
+    smartSelect.selectEl.selectedIndex = -1;
+    filterIcon.classList.remove(".color-theme")
+  },
+
   setCategoriesVisibility: function(container) {
     const labels = app.Settings.get("foodlist", "labels") || [];
     if (labels.length == 0)

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -637,8 +637,11 @@ app.FoodsMealsRecipes = {
     } else {
       let field = element.querySelector("#categories-list");
       field.setAttribute("disabled", "");
-      if (item !== undefined && item.categories !== undefined)
-        field.innerText = item.categories.join(", ");
+      if (item !== undefined && item.categories !== undefined) {
+        field.innerText = labels.filter((label) => {
+          return item.categories.includes(label);
+        }).join(", ");
+      }
     }
   },
 

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -609,6 +609,39 @@ app.FoodsMealsRecipes = {
     return app.FoodsMealsRecipes.selection;
   },
 
+  populateCategoriesField: function(element, item, categoriesEditable) {
+    const labels = app.Settings.get("foodlist", "labels");
+    const categories = app.Settings.get("foodlist", "categories");
+
+    if (categoriesEditable) {
+      let select = document.createElement("select");
+      select.setAttribute("multiple", "");
+      element.firstElementChild.append(select);
+
+      labels.forEach((label) => {
+        let option = document.createElement("option");
+        option.value = label;
+        option.setAttribute("data-display-as", label);
+        option.text = label + " " + categories[label] || "";
+        if (item !== undefined && item.categories !== undefined && item.categories.includes(label))
+          option.setAttribute("selected", "");
+        select.append(option);
+      });
+
+      element.className = "item-link smart-select";
+  
+      app.f7.smartSelect.create({
+        el: element,
+        openIn: "popover"
+      });
+    } else {
+      let field = element.querySelector("#categories-list");
+      field.setAttribute("disabled", "");
+      if (item !== undefined && item.categories !== undefined)
+        field.innerText = item.categories.join(", ");
+    }
+  },
+
   gotoEditor: function(item) {
     let origin;
     if (app.FoodsMealsRecipes.tab !== undefined)

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -212,7 +212,7 @@ app.FoodsMealsRecipes = {
         data.push(match);
       });
 
-      const nutrimentUnits = app.nutrimentUnits;
+      const units = app.nutrimentUnits;
       if (data.length > 0) {
         // Sum item nutrition
         data.forEach((x, i) => {
@@ -226,7 +226,7 @@ app.FoodsMealsRecipes = {
               result[n] = result[n] || 0;
               result[n] += Math.round(x.nutrition[n] * multiplier * 100) / 100;
               if (n === "calories" && x.nutrition["kilojoules"] === undefined) {
-                let kilojoules = app.Utils.convertUnit(x.nutrition.calories, nutrimentUnits.calories, nutrimentUnits.kilojoules);
+                let kilojoules = app.Utils.convertUnit(x.nutrition.calories, units.calories, units.kilojoules);
                 result["kilojoules"] = result["kilojoules"] || 0;
                 result["kilojoules"] += Math.round(kilojoules * multiplier * 100) / 100;
               }
@@ -381,11 +381,11 @@ app.FoodsMealsRecipes = {
     let energy = nutrition.calories;
 
     if (energy !== undefined && !isNaN(energy)) {
-      const nutrimentUnits = app.nutrimentUnits;
+      const units = app.nutrimentUnits;
       const energyUnit = app.Settings.get("units", "energy");
 
-      if (energyUnit == nutrimentUnits.kilojoules)
-        energy = nutrition.kilojoules || app.Utils.convertUnit(energy, nutrimentUnits.calories, nutrimentUnits.kilojoules);
+      if (energyUnit == units.kilojoules)
+        energy = nutrition.kilojoules || app.Utils.convertUnit(energy, units.calories, units.kilojoules);
 
       return energy;
     }

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -622,6 +622,15 @@ app.FoodsMealsRecipes = {
     return app.FoodsMealsRecipes.selection;
   },
 
+  initializeSearchBar: function(element, eventHandlers) {
+    app.f7.searchbar.create({
+      el: element,
+      backdrop: false,
+      customSearch: true,
+      on: eventHandlers
+    });
+  },
+
   populateCategoriesField: function(element, item, enablePicker, enableRipple, pickerEventHandlers) {
     const labels = app.Settings.get("foodlist", "labels") || [];
     const categories = app.Settings.get("foodlist", "categories") || {};

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -485,7 +485,7 @@ app.FoodsMealsRecipes = {
             const labels = app.Settings.get("foodlist", "labels") || [];
             text += labels.filter((label) => {
               return item.categories.includes(label);
-            }).join("") + " ";
+            }).join(" ") + " ";
           }
           text += item.name;
           title.innerHTML = app.Utils.tidyText(text, 50);

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -642,8 +642,8 @@ app.FoodsMealsRecipes = {
     }
   },
 
-  getSelectedCategories: function() {
-    let smartSelect = app.f7.smartSelect.get("#categories");
+  getSelectedCategories: function(element) {
+    let smartSelect = app.f7.smartSelect.get(element);
     let select = smartSelect.selectEl;
     let categories = [...select.options].filter((option) => option.selected).map((option) => option.value);
     if (categories.length > 0)

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -239,19 +239,32 @@ app.FoodsMealsRecipes = {
     });
   },
 
-  filterList: function(term, list) {
+  filterList: function(query, categories, list) {
     let result = list;
 
-    if (term != "") {
-      let exp = new RegExp(term, "i");
+    if (query !== "" || categories !== undefined) {
+      let queryRegExp = new RegExp(query, "i");
+      let categoriesFilter = categories || [];
 
-      //Filter by name and brand
-      result = result.filter(function(el) {
-        if (el) {
-          if (el.name && el.brand)
-            return el.name.match(exp) || el.brand.match(exp);
-          else if (el.name)
-            return el.name.match(exp);
+      // Filter by name, brand and categories
+      result = result.filter((item) => {
+        if (item) {
+          if (item.name && item.brand) {
+            if (!item.name.match(queryRegExp) && !item.brand.match(queryRegExp))
+              return false;
+          } else if (item.name) {
+            if (!item.name.match(queryRegExp))
+              return false;
+          }
+          for (let category of categoriesFilter) {
+            if (item.categories) {
+              if (!item.categories.includes(category))
+                return false;
+            } else {
+              return false;
+            }
+          }
+          return true;
         }
         return false;
       });

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -683,7 +683,7 @@ app.FoodsMealsRecipes = {
   clearSelectedCategories: function(element, filterIcon) {
     let smartSelect = app.f7.smartSelect.get(element);
     smartSelect.selectEl.selectedIndex = -1;
-    filterIcon.classList.remove(".color-theme")
+    filterIcon.classList.remove(".color-theme");
   },
 
   setCategoriesVisibility: function(container) {

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -642,6 +642,15 @@ app.FoodsMealsRecipes = {
     }
   },
 
+  getSelectedCategories: function() {
+    let smartSelect = app.f7.smartSelect.get("#categories");
+    let select = smartSelect.selectEl;
+    let categories = [...select.options].filter((option) => option.selected).map((option) => option.value);
+    if (categories.length > 0)
+      return categories;
+    return undefined;
+  },
+
   gotoEditor: function(item) {
     let origin;
     if (app.FoodsMealsRecipes.tab !== undefined)

--- a/www/activities/foods-meals-recipes/views/food-editor.html
+++ b/www/activities/foods-meals-recipes/views/food-editor.html
@@ -77,6 +77,16 @@
                 </div>
               </li>
 
+              <li class="item-content item-input hide-for-upload" id="categories-container">
+                <a href="" id="categories">
+                  <div class="item-inner">
+                    <div class="item-title item-label" data-localize="food-editor.categories">Categories</div>
+                    <div class="item-input-wrap"></div>
+                    <div class="item-after" id="categories-list"></div>
+                  </div>
+                </a>
+              </li>
+
               <li class="item-content item-input">
                 <div class="item-inner">
                   <div class="item-title item-label" data-localize="food-editor.name">Name</div>

--- a/www/activities/goals/js/goal-editor.js
+++ b/www/activities/goals/js/goal-editor.js
@@ -50,7 +50,9 @@ app.GoalEditor = {
       unit = "%";
     let unitSymbol = app.strings["unit-symbols"][unit] || unit;
 
-    const text = title + ": " + app.Utils.tidyText(name, 50) + " (" + unitSymbol + ")";
+    let text = title + ": " + app.Utils.tidyText(name, 50);
+    if (unitSymbol !== undefined)
+      text += " (" + unitSymbol + ")";
     app.GoalEditor.el.title.innerText = text;
   },
 

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -33,11 +33,11 @@ app.Goals = {
   populateGoalList: function() {
     app.Goals.el.list.innerHTML = "";
 
-    const measurements = app.measurements;
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const stats = measurements.concat(nutriments);
     const nutrimentUnits = app.nutrimentUnits;
     const energyUnit = app.Settings.get("units", "energy");
+    const measurements = app.measurements;
+    const stats = measurements.concat(nutriments);
 
     for (let i in stats) {
       let x = stats[i];
@@ -54,7 +54,9 @@ app.Goals = {
       a.href = "#";
 
       let text = app.strings.nutriments[x] || app.strings.statistics[x] || x;
-      a.innerHTML = app.Utils.tidyText(text, 50) + " (" + unitSymbol + ")";
+      a.innerHTML = app.Utils.tidyText(text, 50);
+      if (unitSymbol !== undefined)
+        a.innerHTML += " (" + unitSymbol + ")";
       li.appendChild(a);
 
       li.addEventListener("click", (e) => {
@@ -72,16 +74,18 @@ app.Goals = {
   },
 
   getGoalUnit(stat, checkPercentGoal=true) {
-    const units = Object.assign(app.Settings.getField("units"), app.nutrimentUnits);
+    const userUnits = app.Settings.getField("units") || {};
+    const customUnits = app.Settings.get("nutriments", "units") || {};
+    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits, userUnits);
 
     if (stat == "body fat")
       return "%";
     if (app.measurements.includes(stat))
-      return (stat == "weight") ? units.weight : units.length;
+      return (stat == "weight") ? nutrimentUnits.weight : nutrimentUnits.length;
     if (checkPercentGoal && app.Goals.isPercentGoal(stat))
       return "%"
     else
-      return units[stat] || "g";
+      return nutrimentUnits[stat];
   },
 
   getGoals: async function(stats, date) {

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -34,7 +34,7 @@ app.Goals = {
     app.Goals.el.list.innerHTML = "";
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const nutrimentUnits = app.nutrimentUnits;
+    const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
     const measurements = app.measurements;
     const stats = measurements.concat(nutriments);
@@ -42,7 +42,7 @@ app.Goals = {
     for (let i in stats) {
       let x = stats[i];
 
-      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) continue;
+      if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) continue;
 
       let unit = app.Goals.getGoalUnit(x);
       let unitSymbol = app.strings["unit-symbols"][unit] || unit;
@@ -74,18 +74,17 @@ app.Goals = {
   },
 
   getGoalUnit(stat, checkPercentGoal=true) {
-    const userUnits = app.Settings.getField("units") || {};
-    const customUnits = app.Settings.get("nutriments", "units") || {};
-    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits, userUnits);
+    const preferredUnits = app.Settings.getField("units") || {};
+    const units = app.Utils.concatObjects(app.Nutriments.getNutrimentUnits(), preferredUnits);
 
     if (stat == "body fat")
       return "%";
     if (app.measurements.includes(stat))
-      return (stat == "weight") ? nutrimentUnits.weight : nutrimentUnits.length;
+      return (stat == "weight") ? units.weight : units.length;
     if (checkPercentGoal && app.Goals.isPercentGoal(stat))
       return "%"
     else
-      return nutrimentUnits[stat];
+      return units[stat];
   },
 
   getGoals: async function(stats, date) {

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -270,6 +270,20 @@ app.Goals = {
 
   isPercentGoal: function(stat) {
     return app.Settings.get("goals", stat + "-percent-goal");
+  },
+
+  migrateStatGoalSettings: function(oldStat, newStat) {
+    let goals = app.Settings.getField("goals");
+
+    ["", "-show-in-diary", "-show-in-stats", "-shared-goal", "-auto-adjust", "-minimum-goal", "-percent-goal"].forEach((setting) => {
+      if (oldStat + setting in goals) {
+        if (newStat !== undefined)
+          goals[newStat + setting] = goals[oldStat + setting];
+        delete goals[oldStat + setting];
+      }
+    });
+
+    app.Settings.putField("goals", goals);
   }
 };
 

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -47,15 +47,21 @@ app.MealEditor = {
 
     app.MealEditor.setRequiredFieldErrorMessage();
     app.MealEditor.bindUIActions();
+    app.MealEditor.setComponentVisibility();
   },
 
   getComponents: function() {
     app.MealEditor.el.submit = document.querySelector(".page[data-name='meal-editor'] #submit");
+    app.MealEditor.el.categoriesContainer = document.querySelector(".page[data-name='meal-editor'] #categories-container");
     app.MealEditor.el.categories = document.querySelector(".page[data-name='meal-editor'] #categories");
     app.MealEditor.el.nameInput = document.querySelector(".page[data-name='meal-editor'] #name");
     app.MealEditor.el.foodlist = document.querySelector(".page[data-name='meal-editor'] #meal-food-list");
     app.MealEditor.el.add = document.querySelector(".page[data-name='meal-editor'] #add-food");
     app.MealEditor.el.nutrition = document.querySelector(".page[data-name='meal-editor'] #nutrition");
+  },
+
+  setComponentVisibility: function() {
+    app.FoodsMealsRecipes.setCategoriesVisibility(app.MealEditor.el.categoriesContainer);
   },
 
   bindUIActions: function() {

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -158,7 +158,7 @@ app.MealEditor = {
           data[x.name] = x.value;
       });
 
-      let categories = app.FoodsMealsRecipes.getSelectedCategories();
+      let categories = app.FoodsMealsRecipes.getSelectedCategories(app.MealEditor.el.categories);
       if (categories !== undefined)
         data.categories = categories;
 

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -158,6 +158,10 @@ app.MealEditor = {
           data[x.name] = x.value;
       });
 
+      let categories = app.FoodsMealsRecipes.getSelectedCategories();
+      if (categories !== undefined)
+        data.categories = categories;
+
       // Array index should not be saved with items
       if (data.items !== undefined) {
         data.items.forEach((x) => {

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -189,40 +189,45 @@ app.MealEditor = {
 
   renderNutrition: async function() {
     const nutrition = await app.FoodsMealsRecipes.getTotalNutrition(app.MealEditor.meal.items);
-    const nutrimentUnits = app.nutrimentUnits;
+
+    const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    const customUnits = app.Settings.get("nutriments", "units") || {};
+    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
     const energyUnit = app.Settings.get("units", "energy");
-    const nutrimentVisibility = app.Settings.getField("nutrimentVisibility");
+    const visible = app.Settings.getField("nutrimentVisibility");
+
     const ul = app.MealEditor.el.nutrition;
     ul.innerHTML = "";
 
-    for (let n in nutrition) {
-      if (nutrition[n] !== 0) {
+    nutriments.forEach((x) => {
 
-        if ((n == "calories" || n == "kilojoules") && nutrimentUnits[n] != energyUnit) continue;
-        if (nutrimentVisibility[n] !== true && !["calories", "kilojoules"].includes(n)) continue;
+      if (nutrition[x] == undefined || nutrition[x] == 0) return;
+      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if (visible[x] !== true && !["calories", "kilojoules"].includes(x)) return;
 
-        let unit = app.strings["unit-symbols"][nutrimentUnits[n]] || "g";
+      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
 
-        let li = document.createElement("li");
-        li.className = "item-content item-input";
-        ul.appendChild(li);
+      let li = document.createElement("li");
+      li.className = "item-content item-input";
+      ul.appendChild(li);
 
-        let innerDiv = document.createElement("div");
-        innerDiv.className = "item-inner";
-        li.appendChild(innerDiv);
+      let innerDiv = document.createElement("div");
+      innerDiv.className = "item-inner";
+      li.appendChild(innerDiv);
 
-        let title = document.createElement("div");
-        title.className = "item-title item-label";
-        let text = app.strings.nutriments[n] || n;
-        title.innerHTML = app.Utils.tidyText(text, 25) + " (" + unit + ")";
-        innerDiv.appendChild(title);
+      let title = document.createElement("div");
+      title.className = "item-title item-label";
+      let text = app.strings.nutriments[x] || x;
+      title.innerHTML = app.Utils.tidyText(text, 25);
+      if (unit !== undefined)
+        title.innerHTML += " (" + unit + ")";
+      innerDiv.appendChild(title);
 
-        let after = document.createElement("div");
-        after.className = "item-after";
-        after.innerHTML = Math.round(nutrition[n] * 100) / 100;
-        innerDiv.appendChild(after);
-      }
-    }
+      let after = document.createElement("div");
+      after.className = "item-after";
+      after.innerHTML = Math.round(nutrition[x] * 100) / 100;
+      innerDiv.appendChild(after);
+    });
   },
 
   renderItems: function() {

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -31,6 +31,7 @@ app.MealEditor = {
       if (context.meal) {
         app.MealEditor.meal = context.meal;
         app.MealEditor.populateInputs(context.meal);
+        app.FoodsMealsRecipes.populateCategoriesField(app.MealEditor.el.categories, app.MealEditor.meal, true);
       }
 
       if (context.items)
@@ -50,6 +51,7 @@ app.MealEditor = {
 
   getComponents: function() {
     app.MealEditor.el.submit = document.querySelector(".page[data-name='meal-editor'] #submit");
+    app.MealEditor.el.categories = document.querySelector(".page[data-name='meal-editor'] #categories");
     app.MealEditor.el.nameInput = document.querySelector(".page[data-name='meal-editor'] #name");
     app.MealEditor.el.foodlist = document.querySelector(".page[data-name='meal-editor'] #meal-food-list");
     app.MealEditor.el.add = document.querySelector(".page[data-name='meal-editor'] #add-food");

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -31,7 +31,7 @@ app.MealEditor = {
       if (context.meal) {
         app.MealEditor.meal = context.meal;
         app.MealEditor.populateInputs(context.meal);
-        app.FoodsMealsRecipes.populateCategoriesField(app.MealEditor.el.categories, app.MealEditor.meal, true);
+        app.FoodsMealsRecipes.populateCategoriesField(app.MealEditor.el.categories, app.MealEditor.meal, true, true);
       }
 
       if (context.items)

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -191,8 +191,7 @@ app.MealEditor = {
     const nutrition = await app.FoodsMealsRecipes.getTotalNutrition(app.MealEditor.meal.items);
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const customUnits = app.Settings.get("nutriments", "units") || {};
-    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+    const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
     const visible = app.Settings.getField("nutrimentVisibility");
 
@@ -202,10 +201,10 @@ app.MealEditor = {
     nutriments.forEach((x) => {
 
       if (nutrition[x] == undefined || nutrition[x] == 0) return;
-      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) return;
       if (visible[x] !== true && !["calories", "kilojoules"].includes(x)) return;
 
-      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
+      let unit = app.strings["unit-symbols"][units[x]] || units[x];
 
       let li = document.createElement("li");
       li.className = "item-content item-input";

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -212,18 +212,13 @@ app.Meals = {
   },
 
   createSearchBar: function() {
-    const searchBar = app.f7.searchbar.create({
-      el: app.Meals.el.searchForm,
-      backdrop: false,
-      customSearch: true,
-      on: {
-        async search(searchbar, query, previousQuery) {
-          if (query == "")
-            app.Meals.filterList = await app.Meals.getListFromDB();
-          app.Meals.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Meals.filterList);
-          app.Meals.renderList(true);
-        },
-      }
+    app.FoodsMealsRecipes.initializeSearchBar(app.Meals.el.searchForm, {
+      searchbarSearch: async (searchbar, query, previousQuery) => {
+        if (query == "")
+          app.Meals.filterList = await app.Meals.getListFromDB();
+        app.Meals.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Meals.filterList);
+        app.Meals.renderList(true);
+      },
     });
   },
 };

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -59,7 +59,6 @@ app.Meals = {
     app.Meals.el.fab = document.querySelector("#add-meal");
     app.Meals.el.infinite = document.querySelector(".page[data-name='foods-meals-recipes'] #meals"); //Infinite list container
     app.Meals.el.list = document.querySelector("#meal-list-container ul"); //Infinite list
-    app.Meals.el.spinner = document.querySelector("#meals-tab #spinner");
   },
 
   bindUIActions: function() {

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -223,6 +223,12 @@ app.Meals = {
         app.Meals.list = app.FoodsMealsRecipes.filterList(query, categories, app.Meals.filterList);
         app.Meals.renderList(true);
       },
+      searchbarDisable: async (searchbar) => {
+        app.FoodsMealsRecipes.clearSelectedCategories(app.Meals.el.searchFilter, app.Meals.el.searchFilterIcon);
+        app.Meals.filterList = await app.Meals.getListFromDB();
+        app.Meals.list = app.Meals.filterList;
+        app.Meals.renderList(true);
+      }
     });
     app.FoodsMealsRecipes.populateCategoriesField(app.Meals.el.searchFilter, undefined, true, false, {
       beforeOpen: (smartSelect, prevent) => {

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -21,11 +21,9 @@ app.Meals = {
 
   list: [], //Main list of foods
   filterList: [], //Copy of the list for filtering
-  selection: [], //Items that have been checked, even if list has been changed
   el: {}, //UI elements
 
   init: async function(context) {
-    app.Meals.selection = []; //Clear out selection when page is reloaded
 
     if (context !== undefined) {
       if (context.meal)
@@ -66,13 +64,20 @@ app.Meals = {
 
   bindUIActions: function() {
 
-    //Infinite list 
+    // Infinite list - render more items
     if (!app.Meals.el.infinite.hasInfiniteEvent) {
       app.Meals.el.infinite.addEventListener("infinite", (e) => {
         this.renderList();
       });
       app.Meals.el.infinite.hasInfiniteEvent = true;
     }
+
+    // Search filter - reset category filter on long press
+    app.Meals.el.searchFilter.addEventListener("taphold", async (e) => {
+      app.FoodsMealsRecipes.clearSelectedCategories(app.Meals.el.searchFilter, app.Meals.el.searchFilterIcon);
+      app.Meals.list = app.FoodsMealsRecipes.filterList(app.Meals.el.search.value, undefined, app.Meals.filterList);
+      app.Meals.renderList(true);
+    });
   },
 
   renderList: async function(clear) {
@@ -221,12 +226,6 @@ app.Meals = {
           app.Meals.filterList = await app.Meals.getListFromDB();
         let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Meals.el.searchFilter);
         app.Meals.list = app.FoodsMealsRecipes.filterList(query, categories, app.Meals.filterList);
-        app.Meals.renderList(true);
-      },
-      searchbarDisable: async (searchbar) => {
-        app.FoodsMealsRecipes.clearSelectedCategories(app.Meals.el.searchFilter, app.Meals.el.searchFilterIcon);
-        app.Meals.filterList = await app.Meals.getListFromDB();
-        app.Meals.list = app.Meals.filterList;
         app.Meals.renderList(true);
       }
     });

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -56,6 +56,9 @@ app.Meals = {
     app.Meals.el.title = document.querySelector(".page[data-name='foods-meals-recipes'] #title");
     app.Meals.el.search = document.querySelector("#meals-tab #meal-search");
     app.Meals.el.searchForm = document.querySelector("#meals-tab #meal-search-form");
+    app.Meals.el.searchFilter = document.querySelector("#meals-tab #meal-search-filter");
+    app.Meals.el.searchFilterIcon = document.querySelector("#meals-tab #meal-search-filter-icon");
+    app.Meals.el.searchFilterContainer = document.querySelector("#meals-tab #meal-search-filter-container");
     app.Meals.el.fab = document.querySelector("#add-meal");
     app.Meals.el.infinite = document.querySelector(".page[data-name='foods-meals-recipes'] #meals"); //Infinite list container
     app.Meals.el.list = document.querySelector("#meal-list-container ul"); //Infinite list
@@ -216,10 +219,27 @@ app.Meals = {
       searchbarSearch: async (searchbar, query, previousQuery) => {
         if (query == "")
           app.Meals.filterList = await app.Meals.getListFromDB();
-        app.Meals.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Meals.filterList);
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Meals.el.searchFilter);
+        app.Meals.list = app.FoodsMealsRecipes.filterList(query, categories, app.Meals.filterList);
         app.Meals.renderList(true);
       },
     });
+    app.FoodsMealsRecipes.populateCategoriesField(app.Meals.el.searchFilter, undefined, true, false, {
+      beforeOpen: (smartSelect, prevent) => {
+        smartSelect.selectEl.selectedIndex = -1;
+      },
+      close: (smartSelect) => {
+        let query = app.Meals.el.search.value;
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Meals.el.searchFilter);
+        if (categories !== undefined)
+          app.Meals.el.searchFilterIcon.classList.add(".color-theme");
+        else
+          app.Meals.el.searchFilterIcon.classList.remove(".color-theme");
+        app.Meals.list = app.FoodsMealsRecipes.filterList(query, categories, app.Meals.filterList);
+        app.Meals.renderList(true);
+      }
+    });
+    app.FoodsMealsRecipes.setCategoriesVisibility(app.Meals.el.searchFilterContainer);
   },
 };
 

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -217,13 +217,10 @@ app.Meals = {
       backdrop: false,
       customSearch: true,
       on: {
-        async search(sb, query, previousQuery) {
-          if (query != "") {
-            app.Meals.list = app.FoodsMealsRecipes.filterList(query, app.Meals.filterList);
-          } else {
-            app.Meals.list = await app.Meals.getListFromDB();
-            app.Meals.filterList = app.Meals.list;
-          }
+        async search(searchbar, query, previousQuery) {
+          if (query == "")
+            app.Meals.filterList = await app.Meals.getListFromDB();
+          app.Meals.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Meals.filterList);
           app.Meals.renderList(true);
         },
       }

--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -48,6 +48,16 @@
           <div class="accordion-item-content inline-labels">
             <ul>
               <li class="item-content item-input">
+                <a href="" id="categories">
+                  <div class="item-inner">
+                    <div class="item-title item-label" data-localize="food-editor.categories">Categories</div>
+                    <div class="item-input-wrap"></div>
+                    <div class="item-after" id="categories-list"></div>
+                  </div>
+                </a>
+              </li>
+
+              <li class="item-content item-input">
                 <div class="item-inner">
                   <div class="item-title item-label" data-localize="food-editor.name">Name</div>
                   <div class="item-input-wrap">

--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -47,7 +47,7 @@
           </a>
           <div class="accordion-item-content inline-labels">
             <ul>
-              <li class="item-content item-input">
+              <li class="item-content item-input" id="categories-container">
                 <a href="" id="categories">
                   <div class="item-inner">
                     <div class="item-title item-label" data-localize="food-editor.categories">Categories</div>

--- a/www/activities/meals/views/meals.html
+++ b/www/activities/meals/views/meals.html
@@ -27,6 +27,16 @@
         <i class="searchbar-icon"></i>
       </div>
       <span class="searchbar-disable-button">Cancel</span>
+      <div slot="inner-end" id="meal-search-filter-container">
+        <a id="meal-search-filter">
+          <div class="item-inner"></div>
+          <div class="item-content">
+            <div class="margin-horizontal">
+              <i class="icon fas fa-filter" id="meal-search-filter-icon"></i>
+            </div>
+          </div>
+        </a>
+      </div>
     </div>
   </form>
 

--- a/www/activities/meals/views/meals.html
+++ b/www/activities/meals/views/meals.html
@@ -34,5 +34,4 @@
     <ul>
     </ul>
   </div>
-  <div class="preloader infinite-scroll-preloader" id="spinner" style="display:none;"></div>
 </div>

--- a/www/activities/meals/views/meals.html
+++ b/www/activities/meals/views/meals.html
@@ -30,10 +30,8 @@
       <div slot="inner-end" id="meal-search-filter-container">
         <a id="meal-search-filter">
           <div class="item-inner"></div>
-          <div class="item-content">
-            <div class="margin-horizontal">
-              <i class="icon fas fa-filter" id="meal-search-filter-icon"></i>
-            </div>
+          <div class="margin-horizontal">
+            <i class="icon fas fa-filter" id="meal-search-filter-icon"></i>
           </div>
         </a>
       </div>

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -193,18 +193,23 @@ app.RecipeEditor = {
 
   renderNutrition: async function() {
     const nutrition = await app.FoodsMealsRecipes.getTotalNutrition(app.RecipeEditor.recipe.items);
-    const nutrimentUnits = app.nutrimentUnits;
+
+    const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    const customUnits = app.Settings.get("nutriments", "units") || {};
+    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
     const energyUnit = app.Settings.get("units", "energy");
-    const nutrimentVisibility = app.Settings.getField("nutrimentVisibility");
+    const visible = app.Settings.getField("nutrimentVisibility");
+
     const ul = app.RecipeEditor.el.nutrition;
     ul.innerHTML = "";
 
-    for (let n in nutrition) {
+    nutriments.forEach((x) => {
 
-      if ((n == "calories" || n == "kilojoules") && nutrimentUnits[n] != energyUnit) continue;
-      if (nutrimentVisibility[n] !== true && !["calories", "kilojoules"].includes(n)) continue;
+      if (nutrition[x] == undefined || nutrition[x] == 0) return;
+      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if (visible[x] !== true && !["calories", "kilojoules"].includes(x)) return;
 
-      let unit = app.strings["unit-symbols"][nutrimentUnits[n]] || "g";
+      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
 
       let li = document.createElement("li");
       li.className = "item-content item-input";
@@ -216,15 +221,17 @@ app.RecipeEditor = {
 
       let title = document.createElement("div");
       title.className = "item-title item-label";
-      let text = app.strings.nutriments[n] || n;
-      title.innerHTML = app.Utils.tidyText(text, 25) + " (" + unit + ")";
+      let text = app.strings.nutriments[x] || x;
+      title.innerHTML = app.Utils.tidyText(text, 25);
+      if (unit !== undefined)
+        title.innerHTML += " (" + unit + ")";
       innerDiv.appendChild(title);
 
       let after = document.createElement("div");
       after.className = "item-after";
-      after.innerHTML = Math.round(nutrition[n] * 100) / 100;
+      after.innerHTML = Math.round(nutrition[x] * 100) / 100;
       innerDiv.appendChild(after);
-    }
+    });
   },
 
   renderItems: function() {

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -159,7 +159,7 @@ app.RecipeEditor = {
           data[x.name] = x.value;
       });
 
-      let categories = app.FoodsMealsRecipes.getSelectedCategories();
+      let categories = app.FoodsMealsRecipes.getSelectedCategories(app.RecipeEditor.el.categories);
       if (categories !== undefined)
         data.categories = categories;
 

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -31,7 +31,7 @@ app.RecipeEditor = {
       if (context.recipe) {
         app.RecipeEditor.recipe = context.recipe;
         app.RecipeEditor.populateInputs(context.recipe);
-        app.FoodsMealsRecipes.populateCategoriesField(app.RecipeEditor.el.categories, app.RecipeEditor.recipe, true);
+        app.FoodsMealsRecipes.populateCategoriesField(app.RecipeEditor.el.categories, app.RecipeEditor.recipe, true, true);
       }
 
       // From food list

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -48,15 +48,21 @@ app.RecipeEditor = {
 
     app.RecipeEditor.setRequiredFieldErrorMessage();
     app.RecipeEditor.bindUIActions();
+    app.RecipeEditor.setComponentVisibility();
   },
 
   getComponents: function() {
     app.RecipeEditor.el.submit = document.querySelector(".page[data-name='recipe-editor'] #submit");
+    app.RecipeEditor.el.categoriesContainer = document.querySelector(".page[data-name='recipe-editor'] #categories-container");
     app.RecipeEditor.el.categories = document.querySelector(".page[data-name='recipe-editor'] #categories");
     app.RecipeEditor.el.nameInput = document.querySelector(".page[data-name='recipe-editor'] #name");
     app.RecipeEditor.el.foodlist = document.querySelector(".page[data-name='recipe-editor'] #recipe-food-list");
     app.RecipeEditor.el.add = document.querySelector(".page[data-name='recipe-editor'] #add-food");
     app.RecipeEditor.el.nutrition = document.querySelector(".page[data-name='recipe-editor'] #nutrition");
+  },
+
+  setComponentVisibility: function() {
+    app.FoodsMealsRecipes.setCategoriesVisibility(app.RecipeEditor.el.categoriesContainer);
   },
 
   bindUIActions: function() {

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -159,6 +159,10 @@ app.RecipeEditor = {
           data[x.name] = x.value;
       });
 
+      let categories = app.FoodsMealsRecipes.getSelectedCategories();
+      if (categories !== undefined)
+        data.categories = categories;
+
       // Array index should not be saved with items
       if (data.items !== undefined) {
         data.items.forEach((x) => {

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -31,6 +31,7 @@ app.RecipeEditor = {
       if (context.recipe) {
         app.RecipeEditor.recipe = context.recipe;
         app.RecipeEditor.populateInputs(context.recipe);
+        app.FoodsMealsRecipes.populateCategoriesField(app.RecipeEditor.el.categories, app.RecipeEditor.recipe, true);
       }
 
       // From food list
@@ -51,6 +52,7 @@ app.RecipeEditor = {
 
   getComponents: function() {
     app.RecipeEditor.el.submit = document.querySelector(".page[data-name='recipe-editor'] #submit");
+    app.RecipeEditor.el.categories = document.querySelector(".page[data-name='recipe-editor'] #categories");
     app.RecipeEditor.el.nameInput = document.querySelector(".page[data-name='recipe-editor'] #name");
     app.RecipeEditor.el.foodlist = document.querySelector(".page[data-name='recipe-editor'] #recipe-food-list");
     app.RecipeEditor.el.add = document.querySelector(".page[data-name='recipe-editor'] #add-food");

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -195,8 +195,7 @@ app.RecipeEditor = {
     const nutrition = await app.FoodsMealsRecipes.getTotalNutrition(app.RecipeEditor.recipe.items);
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const customUnits = app.Settings.get("nutriments", "units") || {};
-    const nutrimentUnits = app.Utils.concatObjects(app.nutrimentUnits, customUnits);
+    const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
     const visible = app.Settings.getField("nutrimentVisibility");
 
@@ -206,10 +205,10 @@ app.RecipeEditor = {
     nutriments.forEach((x) => {
 
       if (nutrition[x] == undefined || nutrition[x] == 0) return;
-      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) return;
       if (visible[x] !== true && !["calories", "kilojoules"].includes(x)) return;
 
-      let unit = app.strings["unit-symbols"][nutrimentUnits[x]] || nutrimentUnits[x];
+      let unit = app.strings["unit-symbols"][units[x]] || units[x];
 
       let li = document.createElement("li");
       li.className = "item-content item-input";

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -21,11 +21,9 @@ app.Recipes = {
 
   list: [], //Main list of foods
   filterList: [], //Copy of the list for filtering
-  selection: [], //Items that have been checked, even if list has been changed
   el: {}, //UI elements
 
   init: async function(context) {
-    app.Recipes.selection = []; //Clear out selection when page is reloaded
 
     if (context !== undefined) {
       if (context.recipe)
@@ -66,13 +64,20 @@ app.Recipes = {
 
   bindUIActions: function() {
 
-    //Infinite list 
+    // Infinite list - render more items
     if (!app.Recipes.el.infinite.hasInfiniteEvent) {
       app.Recipes.el.infinite.addEventListener("infinite", (e) => {
         app.Recipes.renderList();
       });
       app.Recipes.el.infinite.hasInfiniteEvent = true;
     }
+
+    // Search filter - reset category filter on long press
+    app.Recipes.el.searchFilter.addEventListener("taphold", async (e) => {
+      app.FoodsMealsRecipes.clearSelectedCategories(app.Recipes.el.searchFilter, app.Recipes.el.searchFilterIcon);
+      app.Recipes.list = app.FoodsMealsRecipes.filterList(app.Recipes.el.search.value, undefined, app.Recipes.filterList);
+      app.Recipes.renderList(true);
+    });
   },
 
   renderList: async function(clear) {
@@ -166,12 +171,6 @@ app.Recipes = {
           app.Recipes.filterList = await app.Recipes.getListFromDB();
         let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Recipes.el.searchFilter);
         app.Recipes.list = app.FoodsMealsRecipes.filterList(query, categories, app.Recipes.filterList);
-        app.Recipes.renderList(true);
-      },
-      searchbarDisable: async (searchbar) => {
-        app.FoodsMealsRecipes.clearSelectedCategories(app.Recipes.el.searchFilter, app.Recipes.el.searchFilterIcon);
-        app.Recipes.filterList = await app.Recipes.getListFromDB();
-        app.Recipes.list = app.Recipes.filterList;
         app.Recipes.renderList(true);
       }
     });

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -56,6 +56,9 @@ app.Recipes = {
     app.Recipes.el.title = document.querySelector(".page[data-name='foods-meals-recipes'] #title");
     app.Recipes.el.search = document.querySelector("#recipes-tab #recipe-search");
     app.Recipes.el.searchForm = document.querySelector("#recipes-tab #recipe-search-form");
+    app.Recipes.el.searchFilter = document.querySelector("#recipes-tab #recipe-search-filter");
+    app.Recipes.el.searchFilterIcon = document.querySelector("#recipes-tab #recipe-search-filter-icon");
+    app.Recipes.el.searchFilterContainer = document.querySelector("#recipes-tab #recipe-search-filter-container");
     app.Recipes.el.fab = document.querySelector("#add-recipe");
     app.Recipes.el.infinite = document.querySelector(".page[data-name='foods-meals-recipes'] #recipes"); //Infinite list container
     app.Recipes.el.list = document.querySelector("#recipe-list-container ul"); //Infinite list
@@ -161,10 +164,27 @@ app.Recipes = {
       searchbarSearch: async (searchbar, query, previousQuery) => {
         if (query == "")
           app.Recipes.filterList = await app.Recipes.getListFromDB();
-        app.Recipes.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Recipes.filterList);
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Recipes.el.searchFilter);
+        app.Recipes.list = app.FoodsMealsRecipes.filterList(query, categories, app.Recipes.filterList);
         app.Recipes.renderList(true);
       },
     });
+    app.FoodsMealsRecipes.populateCategoriesField(app.Recipes.el.searchFilter, undefined, true, false, {
+      beforeOpen: (smartSelect, prevent) => {
+        smartSelect.selectEl.selectedIndex = -1;
+      },
+      close: (smartSelect) => {
+        let query = app.Recipes.el.search.value;
+        let categories = app.FoodsMealsRecipes.getSelectedCategories(app.Recipes.el.searchFilter);
+        if (categories !== undefined)
+          app.Recipes.el.searchFilterIcon.classList.add(".color-theme");
+        else
+          app.Recipes.el.searchFilterIcon.classList.remove(".color-theme");
+        app.Recipes.list = app.FoodsMealsRecipes.filterList(query, categories, app.Recipes.filterList);
+        app.Recipes.renderList(true);
+      }
+    });
+    app.FoodsMealsRecipes.setCategoriesVisibility(app.Recipes.el.searchFilterContainer);
   },
 };
 

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -157,18 +157,13 @@ app.Recipes = {
   },
 
   createSearchBar: function() {
-    const searchBar = app.f7.searchbar.create({
-      el: app.Recipes.el.searchForm,
-      backdrop: false,
-      customSearch: true,
-      on: {
-        async search(searchbar, query, previousQuery) {
-          if (query == "")
-            app.Recipes.filterList = await app.Recipes.getListFromDB();
-          app.Recipes.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Recipes.filterList);
-          app.Recipes.renderList(true);
-        },
-      }
+    app.FoodsMealsRecipes.initializeSearchBar(app.Recipes.el.searchForm, {
+      searchbarSearch: async (searchbar, query, previousQuery) => {
+        if (query == "")
+          app.Recipes.filterList = await app.Recipes.getListFromDB();
+        app.Recipes.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Recipes.filterList);
+        app.Recipes.renderList(true);
+      },
     });
   },
 };

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -168,6 +168,12 @@ app.Recipes = {
         app.Recipes.list = app.FoodsMealsRecipes.filterList(query, categories, app.Recipes.filterList);
         app.Recipes.renderList(true);
       },
+      searchbarDisable: async (searchbar) => {
+        app.FoodsMealsRecipes.clearSelectedCategories(app.Recipes.el.searchFilter, app.Recipes.el.searchFilterIcon);
+        app.Recipes.filterList = await app.Recipes.getListFromDB();
+        app.Recipes.list = app.Recipes.filterList;
+        app.Recipes.renderList(true);
+      }
     });
     app.FoodsMealsRecipes.populateCategoriesField(app.Recipes.el.searchFilter, undefined, true, false, {
       beforeOpen: (smartSelect, prevent) => {

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -162,13 +162,10 @@ app.Recipes = {
       backdrop: false,
       customSearch: true,
       on: {
-        async search(sb, query, previousQuery) {
-          if (query != "") {
-            app.Recipes.list = app.FoodsMealsRecipes.filterList(query, app.Recipes.filterList);
-          } else {
-            app.Recipes.list = await app.Recipes.getListFromDB();
-            app.Recipes.filterList = app.Recipes.list;
-          }
+        async search(searchbar, query, previousQuery) {
+          if (query == "")
+            app.Recipes.filterList = await app.Recipes.getListFromDB();
+          app.Recipes.list = app.FoodsMealsRecipes.filterList(query, undefined, app.Recipes.filterList);
           app.Recipes.renderList(true);
         },
       }

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -59,7 +59,6 @@ app.Recipes = {
     app.Recipes.el.fab = document.querySelector("#add-recipe");
     app.Recipes.el.infinite = document.querySelector(".page[data-name='foods-meals-recipes'] #recipes"); //Infinite list container
     app.Recipes.el.list = document.querySelector("#recipe-list-container ul"); //Infinite list
-    app.Recipes.el.spinner = document.querySelector("#recipes-tab #spinner");
   },
 
   bindUIActions: function() {

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -38,6 +38,7 @@
 
     <form class="list" id="recipe-edit-form">
       <ul>
+
         <li class="accordion-item accordion-item-opened">
           <a href="" class="item-divider item-link item-content">
             <div class="item-inner">
@@ -46,6 +47,16 @@
           </a>
           <div class="accordion-item-content">
             <ul>
+              <li class="item-content item-input inline-labels">
+                <a href="" id="categories">
+                  <div class="item-inner">
+                    <div class="item-title item-label" data-localize="food-editor.categories">Categories</div>
+                    <div class="item-input-wrap"></div>
+                    <div class="item-after" id="categories-list"></div>
+                  </div>
+                </a>
+              </li>
+
               <li class="item-content item-input inline-labels">
                 <div class="item-inner">
                   <div class="item-title item-label" data-localize="food-editor.name">Name</div>

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -47,7 +47,7 @@
           </a>
           <div class="accordion-item-content">
             <ul>
-              <li class="item-content item-input inline-labels">
+              <li class="item-content item-input inline-labels" id="categories-container">
                 <a href="" id="categories">
                   <div class="item-inner">
                     <div class="item-title item-label" data-localize="food-editor.categories">Categories</div>

--- a/www/activities/recipes/views/recipes.html
+++ b/www/activities/recipes/views/recipes.html
@@ -27,6 +27,16 @@
         <i class="searchbar-icon"></i>
       </div>
       <span class="searchbar-disable-button">Cancel</span>
+      <div slot="inner-end" id="recipe-search-filter-container">
+        <a id="recipe-search-filter">
+          <div class="item-inner"></div>
+          <div class="item-content">
+            <div class="margin-horizontal">
+              <i class="icon fas fa-filter" id="recipe-search-filter-icon"></i>
+            </div>
+          </div>
+        </a>
+      </div>
     </div>
   </form>
 

--- a/www/activities/recipes/views/recipes.html
+++ b/www/activities/recipes/views/recipes.html
@@ -34,5 +34,4 @@
     <ul>
     </ul>
   </div>
-  <div class="preloader infinite-scroll-preloader" id="spinner" style="display:none;"></div>
 </div>

--- a/www/activities/recipes/views/recipes.html
+++ b/www/activities/recipes/views/recipes.html
@@ -30,10 +30,8 @@
       <div slot="inner-end" id="recipe-search-filter-container">
         <a id="recipe-search-filter">
           <div class="item-inner"></div>
-          <div class="item-content">
-            <div class="margin-horizontal">
-              <i class="icon fas fa-filter" id="recipe-search-filter-icon"></i>
-            </div>
+          <div class="margin-horizontal">
+            <i class="icon fas fa-filter" id="recipe-search-filter-icon"></i>
           </div>
         </a>
       </div>

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -203,8 +203,9 @@ app.FoodsCategories = {
           app.Settings.put("foodlist", "labels", labels);
 
           // Update category label for all foods, meals and recipes
+          const condition = IDBKeyRange.only(oldLabel);
           for (let store of app.FoodsCategories.storeNames) {
-            await dbHandler.processAllItems(store, (cursor) => {
+            await dbHandler.processItems(store, "categories", condition, (cursor) => {
               let item = cursor.value;
               if (item.categories !== undefined) {
                 let index = item.categories.indexOf(oldLabel);
@@ -260,8 +261,9 @@ app.FoodsCategories = {
             app.Settings.put("foodlist", "categories", categories);
 
             // Delete this category from all foods, meals and recipes
+            const condition = IDBKeyRange.only(label);
             for (let store of app.FoodsCategories.storeNames) {
-              await dbHandler.processAllItems(store, (cursor) => {
+              await dbHandler.processItems(store, "categories", condition, (cursor) => {
                 let item = cursor.value;
                 if (item.categories !== undefined) {
                   let index = item.categories.indexOf(label);

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -1,0 +1,86 @@
+/*
+  Copyright 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+app.FoodsCategories = {
+
+  defaultLabels: ["🌳", "🏪"],
+  defaultCategories: {"🌳": "", "🏪": ""},
+
+  populateFoodCategoriesList: function() {
+    let labels = app.Settings.get("foodlist", "labels") || [];
+    let categories = app.Settings.get("foodlist", "categories") || {};
+    let ul = document.querySelector("#food-categories-list");
+    ul.innerHTML = "";
+
+    labels.forEach((label) => {
+
+      let li = document.createElement("li");
+      li.id = label;
+      ul.appendChild(li);
+
+      let content = document.createElement("div");
+      content.className = "item-content";
+      li.appendChild(content);
+
+      let media = document.createElement("div");
+      media.className = "item-media";
+      content.appendChild(media);
+
+      let icon = document.createElement("span");
+      icon.innerHTML = label;
+      media.appendChild(icon);
+
+      let inner = document.createElement("div");
+      inner.className = "item-inner";
+      content.appendChild(inner);
+
+      let text = categories[label] || "";
+      let title = document.createElement("div");
+      title.className = "item-title";
+      title.innerHTML = app.Utils.tidyText(text, 50);
+      inner.appendChild(title);
+
+      let after = document.createElement("div");
+      after.className = "item-after";
+      inner.appendChild(after);
+
+      let editHandler = document.createElement("a");
+      editHandler.className = "link icon-only margin-horizontal";
+      after.appendChild(editHandler);
+
+      let editIcon = document.createElement("i");
+      editIcon.className = "icon material-icons";
+      editIcon.innerHTML = "edit";
+      editHandler.appendChild(editIcon);
+
+      let deleteHandler = document.createElement("a");
+      deleteHandler.className = "link icon-only";
+      after.appendChild(deleteHandler);
+
+      let deleteIcon = document.createElement("i");
+      deleteIcon.className = "icon material-icons";
+      deleteIcon.innerHTML = "delete";
+      deleteHandler.appendChild(deleteIcon);
+
+      let sortHandler = document.createElement("div");
+      sortHandler.className = "sortable-handler";
+      li.appendChild(sortHandler);
+    });
+  }
+};

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -190,7 +190,7 @@ app.FoodsCategories = {
     let title = app.strings.settings["foods-categories"]["edit"] || "Edit Category";
 
     app.FoodsCategories.showFoodCategoryDialog(title, oldLabel, oldDescription, async (newLabel, newDescription) => {
-      if (newLabel !== "" && !labels.includes(newLabel)) {
+      if (newLabel !== "" && (newLabel == oldLabel || !labels.includes(newLabel))) {
 
         if (newLabel !== oldLabel) {
           app.f7.preloader.show();

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -135,7 +135,7 @@ app.FoodsCategories = {
       input.type = "text";
       if (field == "label") {
         input.setAttribute("value", label || "");
-        input.setAttribute("maxlength", "4");
+        input.setAttribute("maxlength", "8");
       } else {
         input.setAttribute("value", description || "");
       }

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -19,6 +19,7 @@
 
 app.FoodsCategories = {
 
+  storeNames: ["foodList", "meals", "recipes"],
   defaultLabels: ["🌳", "🏪"],
   defaultCategories: {"🌳": "", "🏪": ""},
 
@@ -62,6 +63,9 @@ app.FoodsCategories = {
 
       let editHandler = document.createElement("a");
       editHandler.className = "link icon-only margin-horizontal";
+      editHandler.addEventListener("click", function(e) {
+        app.FoodsCategories.editFoodCategory(label);
+      });
       after.appendChild(editHandler);
 
       let editIcon = document.createElement("i");
@@ -71,6 +75,9 @@ app.FoodsCategories = {
 
       let deleteHandler = document.createElement("a");
       deleteHandler.className = "link icon-only";
+      deleteHandler.addEventListener("click", function(e) {
+        app.FoodsCategories.deleteFoodCategory(label);
+      });
       after.appendChild(deleteHandler);
 
       let deleteIcon = document.createElement("i");
@@ -82,5 +89,198 @@ app.FoodsCategories = {
       sortHandler.className = "sortable-handler";
       li.appendChild(sortHandler);
     });
+
+    let li = document.createElement("li");
+    li.className = "no-sorting";
+    ul.appendChild(li);
+
+    let button = document.createElement("a");
+    button.className = "list-button";
+    button.innerHTML = app.strings.settings["foods-categories"]["add"] || "Add Category";
+    button.addEventListener("click", function(e) {
+      app.FoodsCategories.addFoodCategory();
+    });
+    li.appendChild(button);
+  },
+
+  showFoodCategoryDialog: function(title, label, description, callback) {
+
+    // Create dialog inputs
+    let inputs = document.createElement("form");
+    inputs.className = "list no-hairlines-md";
+
+    let ul = document.createElement("ul");
+    inputs.appendChild(ul);
+
+    ["label", "description"].forEach((field) => {
+      let li = document.createElement("li");
+      li.className = "item-content item-input";
+      ul.appendChild(li);
+
+      let inner = document.createElement("div");
+      inner.className = "item-inner";
+      li.appendChild(inner);
+
+      let fieldTitle = document.createElement("div");
+      fieldTitle.className = "item-title item-label";
+      fieldTitle.innerHTML = app.strings.settings["foods-categories"][field] || field;
+      inner.appendChild(fieldTitle);
+
+      let inputWrap = document.createElement("div");
+      inputWrap.className = "item-input-wrap";
+      inner.appendChild(inputWrap);
+
+      let input = document.createElement("input");
+      input.className = "dialog-input";
+      input.type = "text";
+      if (field == "label") {
+        input.setAttribute("value", label || "");
+        input.setAttribute("maxlength", "4");
+      } else {
+        input.setAttribute("value", description || "");
+      }
+      inputWrap.appendChild(input);
+    });
+
+    let dialog = app.f7.dialog.create({
+      title: title,
+      content: inputs.outerHTML,
+      buttons: [{
+          text: app.strings.dialogs.cancel || "Cancel",
+          keyCodes: [27]
+        },
+        {
+          text: app.strings.dialogs.ok || "OK",
+          keyCodes: [13],
+          onClick: function(dialog) {
+            let inputs = Array.from(dialog.el.getElementsByTagName("input"));
+            let label = inputs[0].value;
+            let description = inputs[1].value;
+            callback(label, description);
+          }
+        }
+      ]
+    }).open();
+  },
+
+  addFoodCategory: function() {
+    let labels = app.Settings.get("foodlist", "labels") || [];
+    let categories = app.Settings.get("foodlist", "categories") || {};
+
+    let title = app.strings.settings["foods-categories"]["add"] || "Add Category";
+
+    app.FoodsCategories.showFoodCategoryDialog(title, "", "", (label, description) => {
+      if (label !== "" && !labels.includes(label)) {
+        labels.push(label);
+        categories[label] = description;
+
+        app.Settings.put("foodlist", "labels", labels);
+        app.Settings.put("foodlist", "categories", categories);
+
+        app.FoodsCategories.populateFoodCategoriesList();
+      }
+    });
+  },
+
+  editFoodCategory: function(oldLabel) {
+    let labels = app.Settings.get("foodlist", "labels") || [];
+    let categories = app.Settings.get("foodlist", "categories") || {};
+
+    let oldDescription = categories[oldLabel];
+    let title = app.strings.settings["foods-categories"]["edit"] || "Edit Category";
+
+    app.FoodsCategories.showFoodCategoryDialog(title, oldLabel, oldDescription, async (newLabel, newDescription) => {
+      if (newLabel !== "" && !labels.includes(newLabel)) {
+
+        if (newLabel !== oldLabel) {
+          app.f7.preloader.show();
+
+          // Replace category label in settings
+          delete categories[oldLabel];
+          let index = labels.indexOf(oldLabel);
+          if (index != -1)
+            labels.splice(index, 1, newLabel);
+          app.Settings.put("foodlist", "labels", labels);
+
+          // Update category label for all foods, meals and recipes
+          for (let store of app.FoodsCategories.storeNames) {
+            await dbHandler.processAllItems(store, (cursor) => {
+              let item = cursor.value;
+              if (item.categories !== undefined) {
+                let index = item.categories.indexOf(oldLabel);
+                if (index != -1) {
+                  item.categories.splice(index, 1, newLabel);
+                  cursor.update(item);
+                }
+              }
+            });
+          }
+
+          app.f7.preloader.hide();
+        }
+
+        categories[newLabel] = newDescription;
+        app.Settings.put("foodlist", "categories", categories);
+
+        app.FoodsCategories.populateFoodCategoriesList();
+      }
+    });
+  },
+
+  deleteFoodCategory: function(label) {
+    let title = (app.strings.dialogs.delete || "Delete") + ": " + label;
+    let text = app.strings.dialogs["confirm-delete"] || "Are you sure you want to delete this?";
+
+    let div = document.createElement("div");
+    div.className = "dialog-text";
+    div.innerText = text;
+
+    let dialog = app.f7.dialog.create({
+      title: title,
+      content: div.outerHTML,
+      buttons: [{
+          text: app.strings.dialogs.cancel || "Cancel",
+          keyCodes: [27]
+        },
+        {
+          text: app.strings.dialogs.delete || "Delete",
+          keyCodes: [13],
+          onClick: async () => {
+            app.f7.preloader.show();
+
+            let labels = app.Settings.get("foodlist", "labels") || [];
+            let categories = app.Settings.get("foodlist", "categories") || {};
+
+            let index = labels.indexOf(label);
+            if (index != -1)
+              labels.splice(index, 1);
+            delete categories[label];
+
+            app.Settings.put("foodlist", "labels", labels);
+            app.Settings.put("foodlist", "categories", categories);
+
+            // Delete this category from all foods, meals and recipes
+            for (let store of app.FoodsCategories.storeNames) {
+              await dbHandler.processAllItems(store, (cursor) => {
+                let item = cursor.value;
+                if (item.categories !== undefined) {
+                  let index = item.categories.indexOf(label);
+                  if (index != -1) {
+                    item.categories.splice(index, 1);
+                    if (item.categories.length == 0)
+                      delete item.categories;
+                    cursor.update(item);
+                  }
+                }
+              });
+            }
+
+            app.FoodsCategories.populateFoodCategoriesList();
+
+            app.f7.preloader.hide();
+          }
+        }
+      ]
+    }).open();
   }
 };

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -133,12 +133,10 @@ app.FoodsCategories = {
       let input = document.createElement("input");
       input.className = "dialog-input";
       input.type = "text";
-      if (field == "label") {
+      if (field == "label")
         input.setAttribute("value", label || "");
-        input.setAttribute("maxlength", "8");
-      } else {
+      else
         input.setAttribute("value", description || "");
-      }
       inputWrap.appendChild(input);
     });
 

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -1,0 +1,72 @@
+/*
+  Copyright 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+app.Nutriments = {
+
+  populateNutrimentList: function() {
+    let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    let ul = document.querySelector("#nutriment-list");
+
+    for (let i in nutriments) {
+      let n = nutriments[i];
+
+      if (n == "calories" || n == "kilojoules") continue;
+
+      let li = document.createElement("li");
+      li.id = n;
+      ul.appendChild(li);
+
+      let content = document.createElement("div");
+      content.className = "item-content";
+      li.appendChild(content);
+
+      let inner = document.createElement("div");
+      inner.className = "item-inner";
+      content.appendChild(inner);
+
+      let text = app.strings.nutriments[n] || n;
+      let title = document.createElement("div");
+      title.className = "item-title";
+      title.innerHTML = app.Utils.tidyText(text, 50);
+      inner.appendChild(title);
+
+      let after = document.createElement("div");
+      after.className = "item-after";
+      inner.appendChild(after);
+
+      let label = document.createElement("label");
+      label.className = "toggle toggle-init";
+      after.appendChild(label);
+
+      let input = document.createElement("input");
+      input.type = "checkbox";
+      input.name = n;
+      input.setAttribute('field', 'nutrimentVisibility');
+      label.appendChild(input);
+
+      let span = document.createElement("span");
+      span.className = "toggle-icon";
+      label.appendChild(span);
+
+      let sortHandler = document.createElement("div");
+      sortHandler.className = "sortable-handler";
+      li.appendChild(sortHandler);
+    }
+  }
+};

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -284,10 +284,9 @@ app.Nutriments = {
             for (let store of app.Nutriments.storeNames) {
               await dbHandler.processItems(store, undefined, undefined, (cursor) => {
                 let item = cursor.value;
-                if (item.nutriments !== undefined) {
-                  let index = item.nutriments.indexOf(field);
-                  if (index != -1) {
-                    item.nutriments.splice(index, 1);
+                if (item.nutrition !== undefined) {
+                  if (field in item.nutrition) {
+                    delete item.nutrition[field];
                     cursor.update(item);
                   }
                 }

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -177,7 +177,7 @@ app.Nutriments = {
 
     app.Nutriments.showNutrimentDialog(title, "", "", (field, unit) => {
       if (field !== "" && !nutriments.includes(field)) {
-        nutriments.push(field);
+        nutriments.splice(2, 0, field);
         if (unit !== "")
           units[field] = unit;
         visibility[field] = true;

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -19,6 +19,8 @@
 
 app.Nutriments = {
 
+  storeNames: ["foodList", "recipes"],
+
   populateNutrimentList: function() {
     let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
     let ul = document.querySelector("#nutriment-list");
@@ -50,6 +52,32 @@ app.Nutriments = {
       after.className = "item-after";
       inner.appendChild(after);
 
+      if (!app.nutriments.includes(n)) {
+        let editHandler = document.createElement("a");
+        editHandler.className = "link icon-only";
+        editHandler.addEventListener("click", function(e) {
+          app.Nutriments.editNutrimentField(n);
+        });
+        after.appendChild(editHandler);
+
+        let editIcon = document.createElement("i");
+        editIcon.className = "icon material-icons";
+        editIcon.innerHTML = "edit";
+        editHandler.appendChild(editIcon);
+
+        let deleteHandler = document.createElement("a");
+        deleteHandler.className = "link icon-only margin-horizontal";
+        deleteHandler.addEventListener("click", function(e) {
+          app.Nutriments.deleteNutrimentField(n);
+        });
+        after.appendChild(deleteHandler);
+
+        let deleteIcon = document.createElement("i");
+        deleteIcon.className = "icon material-icons";
+        deleteIcon.innerHTML = "delete";
+        deleteHandler.appendChild(deleteIcon);
+      }
+
       let label = document.createElement("label");
       label.className = "toggle toggle-init";
       after.appendChild(label);
@@ -68,5 +96,206 @@ app.Nutriments = {
       sortHandler.className = "sortable-handler";
       li.appendChild(sortHandler);
     }
+
+    let li = document.createElement("li");
+    li.className = "no-sorting";
+    ul.appendChild(li);
+
+    let button = document.createElement("a");
+    button.className = "list-button";
+    button.innerHTML = app.strings.settings.nutriments["add"] || "Add Field";
+    button.addEventListener("click", function(e) {
+      app.Nutriments.addNutrimentField();
+    });
+    li.appendChild(button);
+  },
+
+  showNutrimentDialog: function(title, fieldName, fieldUnit, callback) {
+
+    // Create dialog inputs
+    let inputs = document.createElement("form");
+    inputs.className = "list no-hairlines-md";
+
+    let ul = document.createElement("ul");
+    inputs.appendChild(ul);
+
+    ["field", "unit"].forEach((field) => {
+      let li = document.createElement("li");
+      li.className = "item-content item-input";
+      ul.appendChild(li);
+
+      let inner = document.createElement("div");
+      inner.className = "item-inner";
+      li.appendChild(inner);
+
+      let fieldTitle = document.createElement("div");
+      fieldTitle.className = "item-title item-label";
+      fieldTitle.innerHTML = app.strings.settings.nutriments[field] || field;
+      inner.appendChild(fieldTitle);
+
+      let inputWrap = document.createElement("div");
+      inputWrap.className = "item-input-wrap";
+      inner.appendChild(inputWrap);
+
+      let input = document.createElement("input");
+      input.className = "dialog-input";
+      input.type = "text";
+      if (field == "field")
+        input.setAttribute("value", fieldName || "");
+      else
+        input.setAttribute("value", fieldUnit || "");
+      inputWrap.appendChild(input);
+    });
+
+    let dialog = app.f7.dialog.create({
+      title: title,
+      content: inputs.outerHTML,
+      buttons: [{
+          text: app.strings.dialogs.cancel || "Cancel",
+          keyCodes: [27]
+        },
+        {
+          text: app.strings.dialogs.ok || "OK",
+          keyCodes: [13],
+          onClick: function(dialog) {
+            let inputs = Array.from(dialog.el.getElementsByTagName("input"));
+            let field = inputs[0].value;
+            let unit = inputs[1].value;
+            callback(field, unit);
+          }
+        }
+      ]
+    }).open();
+  },
+
+  addNutrimentField: function() {
+    let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    let units = app.Settings.get("nutriments", "units") || {};
+    let visibility = app.Settings.getField("nutrimentVisibility");
+
+    let title = app.strings.settings.nutriments["add"] || "Add Field";
+
+    app.Nutriments.showNutrimentDialog(title, "", "", (field, unit) => {
+      if (field !== "" && !nutriments.includes(field)) {
+        nutriments.push(field);
+        units[field] = unit;
+        visibility[field] = true;
+
+        app.Settings.put("nutriments", "order", nutriments);
+        app.Settings.put("nutriments", "units", units);
+        app.Settings.putField("nutrimentVisibility", visibility);
+
+        app.f7.views.main.router.refreshPage();
+      }
+    });
+  },
+
+  editNutrimentField: function(oldField) {
+    let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+    let units = app.Settings.get("nutriments", "units") || {};
+    let visibility = app.Settings.getField("nutrimentVisibility");
+
+    let oldUnit = units[oldField];
+    let title = app.strings.settings.nutriments["edit"] || "Edit Field";
+
+    app.Nutriments.showNutrimentDialog(title, oldField, oldUnit, async (newField, newUnit) => {
+      if (newField !== "" && (newField == oldField || !nutriments.includes(newField))) {
+
+        if (newField !== oldField) {
+          app.f7.preloader.show();
+
+          // Replace field in settings
+          delete units[oldField];
+          let index = nutriments.indexOf(oldField);
+          if (index != -1)
+            nutriments.splice(index, 1, newField);
+          app.Settings.put("nutriments", "order", nutriments);
+
+          // Migrate field visibility
+          visibility[newField] = visibility[oldField];
+          delete visibility[oldField];
+          app.Settings.putField("nutrimentVisibility", visibility);
+
+          // Update field name for all foods and recipes
+          for (let store of app.Nutriments.storeNames) {
+            await dbHandler.processItems(store, undefined, undefined, (cursor) => {
+              let item = cursor.value;
+              if (item.nutriments !== undefined) {
+                let index = item.nutriments.indexOf(oldField);
+                if (index != -1) {
+                  item.nutriments.splice(index, 1, newField);
+                  cursor.update(item);
+                }
+              }
+            });
+          }
+
+          app.f7.preloader.hide();
+        }
+
+        units[newField] = newUnit;
+        app.Settings.put("nutriments", "units", units);
+
+        app.f7.views.main.router.refreshPage();
+      }
+    });
+  },
+
+  deleteNutrimentField: function(field) {
+    let title = (app.strings.dialogs.delete || "Delete") + ": " + field;
+    let text = app.strings.dialogs["confirm-delete"] || "Are you sure you want to delete this?";
+
+    let div = document.createElement("div");
+    div.className = "dialog-text";
+    div.innerText = text;
+
+    let dialog = app.f7.dialog.create({
+      title: title,
+      content: div.outerHTML,
+      buttons: [{
+          text: app.strings.dialogs.cancel || "Cancel",
+          keyCodes: [27]
+        },
+        {
+          text: app.strings.dialogs.delete || "Delete",
+          keyCodes: [13],
+          onClick: async () => {
+            app.f7.preloader.show();
+
+            let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
+            let units = app.Settings.get("nutriments", "units") || {};
+            let visibility = app.Settings.getField("nutrimentVisibility");
+
+            let index = nutriments.indexOf(field);
+            if (index != -1)
+              nutriments.splice(index, 1);
+            delete units[field];
+            delete visibility[field];
+
+            app.Settings.put("nutriments", "order", nutriments);
+            app.Settings.put("nutriments", "units", units);
+            app.Settings.putField("nutrimentVisibility", visibility);
+
+            // Delete this field from all foods and recipes
+            for (let store of app.Nutriments.storeNames) {
+              await dbHandler.processItems(store, undefined, undefined, (cursor) => {
+                let item = cursor.value;
+                if (item.nutriments !== undefined) {
+                  let index = item.nutriments.indexOf(field);
+                  if (index != -1) {
+                    item.nutriments.splice(index, 1);
+                    cursor.update(item);
+                  }
+                }
+              });
+            }
+
+            app.f7.views.main.router.refreshPage();
+
+            app.f7.preloader.hide();
+          }
+        }
+      ]
+    }).open();
   }
 };

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -178,7 +178,8 @@ app.Nutriments = {
     app.Nutriments.showNutrimentDialog(title, "", "", (field, unit) => {
       if (field !== "" && !nutriments.includes(field)) {
         nutriments.push(field);
-        units[field] = unit;
+        if (unit !== "")
+          units[field] = unit;
         visibility[field] = true;
 
         app.Settings.put("nutriments", "order", nutriments);
@@ -233,7 +234,10 @@ app.Nutriments = {
           app.f7.preloader.hide();
         }
 
-        units[newField] = newUnit;
+        if (newUnit !== "")
+          units[newField] = newUnit;
+        else
+          delete units[newField];
         app.Settings.put("nutriments", "units", units);
 
         app.f7.views.main.router.refreshPage();

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -21,6 +21,11 @@ app.Nutriments = {
 
   storeNames: ["foodList", "recipes"],
 
+  getNutrimentUnits: function() {
+    const units = app.Settings.get("nutriments", "units") || {};
+    return app.Utils.concatObjects(app.nutrimentUnits, units);
+  },
+
   populateNutrimentList: function() {
     let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
     let ul = document.querySelector("#nutriment-list");

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -221,10 +221,10 @@ app.Nutriments = {
           for (let store of app.Nutriments.storeNames) {
             await dbHandler.processItems(store, undefined, undefined, (cursor) => {
               let item = cursor.value;
-              if (item.nutriments !== undefined) {
-                let index = item.nutriments.indexOf(oldField);
-                if (index != -1) {
-                  item.nutriments.splice(index, 1, newField);
+              if (item.nutrition !== undefined) {
+                if (oldField in item.nutrition) {
+                  item.nutrition[newField] = item.nutrition[oldField];
+                  delete item.nutrition[oldField];
                   cursor.update(item);
                 }
               }

--- a/www/activities/settings/js/nutriments.js
+++ b/www/activities/settings/js/nutriments.js
@@ -222,6 +222,9 @@ app.Nutriments = {
           delete visibility[oldField];
           app.Settings.putField("nutrimentVisibility", visibility);
 
+          // Migrate goals
+          app.Goals.migrateStatGoalSettings(oldField, newField);
+
           // Update field name for all foods and recipes
           for (let store of app.Nutriments.storeNames) {
             await dbHandler.processItems(store, undefined, undefined, (cursor) => {
@@ -284,6 +287,9 @@ app.Nutriments = {
             app.Settings.put("nutriments", "order", nutriments);
             app.Settings.put("nutriments", "units", units);
             app.Settings.putField("nutrimentVisibility", visibility);
+
+            // Delete goals
+            app.Goals.migrateStatGoalSettings(field);
 
             // Delete this field from all foods and recipes
             for (let store of app.Nutriments.storeNames) {

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -25,7 +25,6 @@ var s;
 app.Settings = {
 
   settings: {},
-  nutrimentSortLock: 1,
 
   init: function() {
     s = this.settings; //Assign settings object
@@ -350,57 +349,6 @@ app.Settings = {
     }).open();
   },
 
-  populateNutrimentList: function() {
-    let nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    let ul = document.querySelector("#nutriment-list");
-
-    for (let i in nutriments) {
-      let n = nutriments[i];
-
-      if (n == "calories" || n == "kilojoules") continue;
-
-      let li = document.createElement("li");
-      li.id = n;
-      ul.appendChild(li);
-
-      let content = document.createElement("div");
-      content.className = "item-content";
-      li.appendChild(content);
-
-      let inner = document.createElement("div");
-      inner.className = "item-inner";
-      content.appendChild(inner);
-
-      let text = app.strings.nutriments[n] || n;
-      let title = document.createElement("div");
-      title.className = "item-title";
-      title.innerHTML = app.Utils.tidyText(text, 50);
-      inner.appendChild(title);
-
-      let after = document.createElement("div");
-      after.className = "item-after";
-      inner.appendChild(after);
-
-      let label = document.createElement("label");
-      label.className = "toggle toggle-init";
-      after.appendChild(label);
-
-      let input = document.createElement("input");
-      input.type = "checkbox";
-      input.name = n;
-      input.setAttribute('field', 'nutrimentVisibility');
-      label.appendChild(input);
-
-      let span = document.createElement("span");
-      span.className = "toggle-icon";
-      label.appendChild(span);
-
-      let sortHandler = document.createElement("div");
-      sortHandler.className = "sortable-handler";
-      li.appendChild(sortHandler);
-    }
-  },
-
   firstTimeSetup: function() {
     let defaults = {
       statistics: {
@@ -524,7 +472,7 @@ document.addEventListener("page:init", async function(e) {
   const pageName = e.target.attributes["data-name"].value;
 
   if (pageName == "settings-nutriments")
-    app.Settings.populateNutrimentList();
+    app.Nutriments.populateNutrimentList();
   
   if (pageName == "settings-foods-categories")
     app.FoodsCategories.populateFoodCategoriesList();

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -420,6 +420,7 @@ app.Settings = {
         labels: app.FoodsCategories.defaultLabels,
         categories: app.FoodsCategories.defaultCategories,
         sort: "alpha",
+        "show-category-labels": false,
         "show-thumbnails": false,
         "wifi-thumbnails": true,
         "show-images": true,

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -257,7 +257,8 @@ app.Settings = {
         this.put("integration", "off-username", username);
         this.put("integration", "off-password", password);
         app.f7.loginScreen.close(screen);
-        app.Utils.toast(app.strings.settings.integration["login-success"] || "Login Successful");
+        let msg = app.strings.settings.integration["login-success"] || "Login Successful";
+        app.Utils.toast(msg);
       } else {
         let msg = app.strings.settings.integration["invalid-credentials"] || "Invalid Credentials";
         app.Utils.toast(msg);
@@ -271,7 +272,8 @@ app.Settings = {
       if (key == "" || await app.USDA.testApiKey(key)) {
         this.put("integration", "usda-key", key);
         app.f7.loginScreen.close(screen);
-        app.Utils.toast(app.strings.settings.integration["login-success"] || "Login Successful");
+        let msg = app.strings.settings.integration["login-success"] || "Login Successful";
+        app.Utils.toast(msg);
       } else {
         let msg = app.strings.settings.integration["invalid-api-key"] || "API Key Invalid";
         app.Utils.toast(msg);

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -213,7 +213,7 @@ app.Settings = {
       app.f7.on("sortableSort", (e, data) => {
         let li = categoriesList.getElementsByTagName("li");
         let newOrder = [];
-        for (let i = 0; i < li.length; i++) {
+        for (let i = 0; i < li.length - 1; i++) {
           newOrder.push(li[i].id);
         }
         app.Settings.put("foodlist", "labels", newOrder);

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -60,7 +60,7 @@ app.Settings = {
     return undefined;
   },
 
-  putField: function(field) {
+  putField: function(field, value) {
     let settings = JSON.parse(window.localStorage.getItem("settings")) || {};
     settings[field] = settings[field] || {};
     settings[field] = value;

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -199,7 +199,7 @@ app.Settings = {
       app.f7.on("sortableSort", (e, data) => {
         let li = nutrimentList.getElementsByTagName("li");
         let newOrder = [];
-        for (let i = 0; i < li.length; i++) {
+        for (let i = 0; i < li.length - 1; i++) {
           newOrder.push(li[i].id);
         }
         app.Settings.put("nutriments", "order", newOrder);
@@ -418,7 +418,8 @@ app.Settings = {
         "fat-show-in-stats": true,
       },
       nutriments: {
-        order: ["calories", "kilojoules", "fat", "saturated-fat", "carbohydrates", "sugars", "fiber", "proteins", "salt", "monounsaturated-fat", "polyunsaturated-fat", "trans-fat", "omega-3-fat", "cholesterol", "sodium", "vitamin-a", "vitamin-d", "vitamin-e", "vitamin-k", "vitamin-c", "vitamin-b1", "vitamin-b2", "vitamin-pp", "pantothenic-acid", "vitamin-b6", "biotin", "vitamin-b9", "vitamin-b12", "potassium", "chloride", "calcium", "phosphorus", "iron", "magnesium", "zinc", "copper", "manganese", "fluoride", "selenium", "iodine", "caffeine", "alcohol", "sucrose", "glucose", "fructose", "lactose"]
+        order: ["calories", "kilojoules", "fat", "saturated-fat", "carbohydrates", "sugars", "fiber", "proteins", "salt", "monounsaturated-fat", "polyunsaturated-fat", "trans-fat", "omega-3-fat", "cholesterol", "sodium", "vitamin-a", "vitamin-d", "vitamin-e", "vitamin-k", "vitamin-c", "vitamin-b1", "vitamin-b2", "vitamin-pp", "pantothenic-acid", "vitamin-b6", "biotin", "vitamin-b9", "vitamin-b12", "potassium", "chloride", "calcium", "phosphorus", "iron", "magnesium", "zinc", "copper", "manganese", "fluoride", "selenium", "iodine", "caffeine", "alcohol", "sucrose", "glucose", "fructose", "lactose"],
+        units: {}
       },
       nutrimentVisibility: {
         "fat": true,

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -19,7 +19,7 @@
 
 // After a breaking change to the settings schema, increment this constant
 // and implement the migration in the migrateSettings() function below
-const currentSettingsSchemaVersion = 2;
+const currentSettingsSchemaVersion = 3;
 
 var s;
 app.Settings = {
@@ -204,6 +204,19 @@ app.Settings = {
           newOrder.push(li[i].id);
         }
         app.Settings.put("nutriments", "order", newOrder);
+      });
+    }
+
+    // Food labels/categories list
+    let categoriesList = document.getElementById("food-categories-list");
+    if (categoriesList != undefined) {
+      app.f7.on("sortableSort", (e, data) => {
+        let li = categoriesList.getElementsByTagName("li");
+        let newOrder = [];
+        for (let i = 0; i < li.length; i++) {
+          newOrder.push(li[i].id);
+        }
+        app.Settings.put("foodlist", "labels", newOrder);
       });
     }
   },
@@ -404,6 +417,8 @@ app.Settings = {
         "prompt-add-items": false
       },
       foodlist: {
+        labels: app.FoodsCategories.defaultLabels,
+        categories: app.FoodsCategories.defaultCategories,
         sort: "alpha",
         "show-thumbnails": false,
         "wifi-thumbnails": true,
@@ -488,6 +503,12 @@ app.Settings = {
         });
       }
 
+      // Default food labels and categories must be added
+      if (settings.foodlist !== undefined && settings.foodlist.labels === undefined && settings.foodlist.categories === undefined) {
+        settings.foodlist.labels = app.FoodsCategories.defaultLabels;
+        settings.foodlist.categories = app.FoodsCategories.defaultCategories;
+      }
+
       settings.schemaVersion = currentSettingsSchemaVersion;
 
       if (saveChanges)
@@ -503,6 +524,9 @@ document.addEventListener("page:init", async function(e) {
 
   if (pageName == "settings-nutriments")
     app.Settings.populateNutrimentList();
+  
+  if (pageName == "settings-foods-categories")
+    app.FoodsCategories.populateFoodCategoriesList();
 
   //Settings and all settings subpages
   if (pageName.indexOf("settings") != -1) {

--- a/www/activities/settings/views/foods-categories.html
+++ b/www/activities/settings/views/foods-categories.html
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div class="page" data-name="settings-foods-categories">
+
+  <div class="navbar">
+    <div class="navbar-bg"></div>
+    <div class="navbar-inner">
+      <div class="left">
+        <a class="link back"><i class="icon icon-back"></i></a>
+      </div>
+      <div class="title" data-localize="settings.foods-categories.title">Labels and Categories</div>
+      <div class="right"></div>
+    </div>
+  </div>
+
+  <div class="page-content">
+    <div class="list sortable sortable-tap-hold">
+      <ul id="food-categories-list">
+      </ul>
+    </div>
+  </div>
+
+</div>

--- a/www/activities/settings/views/foods.html
+++ b/www/activities/settings/views/foods.html
@@ -29,8 +29,16 @@
   </div>
 
   <div class="page-content">
+
     <div class="list">
       <ul>
+
+        <li>
+          <a href="/settings/foods/categories/" class="item-link item-content">
+            <div class="item-inner" data-localize="settings.foods-categories.title">Labels and Categories</div>
+          </a>
+        </li>
+
         <li>
           <div class="item-content item-input">
             <div class="item-inner">
@@ -117,5 +125,6 @@
 
       </ul>
     </div>
+
   </div>
 </div>

--- a/www/activities/settings/views/foods.html
+++ b/www/activities/settings/views/foods.html
@@ -56,6 +56,20 @@
         <li>
           <div class="item-content">
             <div class="item-inner">
+              <div class="item-title" data-localize="settings.foods.category-labels">Show Category Labels</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="foodlist" name="show-category-labels" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
               <div class="item-title" data-localize="settings.foods.thumbnails">Show Thumbnails</div>
               <div class="item-after">
                 <label class="toggle toggle-init">

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -209,7 +209,9 @@ app.Stats = {
 
       let after = document.createElement("div");
       after.className = "item-after";
-      after.innerHTML = app.Stats.data.dataset.values[i] + " " + app.Stats.data.dataset.unit;
+      after.innerHTML = app.Stats.data.dataset.values[i];
+      if (app.Stats.data.dataset.unit !== undefined)
+        after.innerHTML += " " + app.Stats.data.dataset.unit;
       inner.appendChild(after);
     }
   },
@@ -234,7 +236,9 @@ app.Stats = {
 
     let after = document.createElement("div");
     after.className = "item-after";
-    after.innerHTML = roundedAverage + " " + unit;
+    after.innerHTML = roundedAverage;
+    if (unit !== undefined)
+      after.innerHTML += " " + unit;
     inner.appendChild(after);
 
     return li;
@@ -258,7 +262,7 @@ app.Stats = {
       for (let i = 0; i < data.timestamps.length; i++) {
         let value;
 
-        if (app.nutriments.indexOf(field) == -1) {
+        if (app.measurements.includes(field)) {
           value = parseFloat(data.stats[i][field]);
 
           if (value != undefined) {
@@ -290,7 +294,9 @@ app.Stats = {
       let title = app.strings.nutriments[field] || app.strings.statistics[field] || field;
       let goal = app.Goals.getAverageGoal(field);
 
-      result.dataset.label = app.Utils.tidyText(title, 50) + " (" + unitSymbol + ")";
+      result.dataset.label = app.Utils.tidyText(title, 50);
+      if (unitSymbol !== undefined)
+        result.dataset.label += " (" + unitSymbol + ")";
       result.average = result.average / result.dates.length || 0;
       result.goal = goal;
 

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -123,13 +123,12 @@ app.Stats = {
 
   populateDropdownOptions: function() {
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
-    const nutrimentUnits = app.nutrimentUnits;
     const energyUnit = app.Settings.get("units", "energy");
     const measurements = app.measurements;
     const stats = measurements.concat(nutriments);
 
     stats.forEach((x, i) => {
-      if ((x == "calories" || x == "kilojoules") && nutrimentUnits[x] != energyUnit) return;
+      if ((x == "calories" || x == "kilojoules") && app.nutrimentUnits[x] != energyUnit) return;
       if (!app.Goals.showInStats(x)) return;
 
       let option = document.createElement("option");

--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -10,6 +10,9 @@ html[dir="rtl"] option {direction: rtl;}
 
 .keep-ltr {direction: ltr;}
 
+#categories { width: 100%; }
+#categories-list:not([disabled]) { color: inherit; }
+
 i.searchbar-icon {margin: -12px 12px;}
 
 .item-content.item-inner {column-gap: 0.8em;}

--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -550,8 +550,18 @@ var dbHandler = {
 
   processItems: function(storeName, index, condition, callbackAction) {
     return new Promise(function(resolve, reject) {
-      var objectStore = DB.transaction(storeName, "readwrite").objectStore(storeName).index(index);
-      var cursorRequest = objectStore.openCursor(condition);
+      var objectStore;
+      var cursorRequest;
+
+      if (index !== undefined)
+        objectStore = DB.transaction(storeName, "readwrite").objectStore(storeName).index(index);
+      else
+        objectStore = DB.transaction(storeName, "readwrite").objectStore(storeName)
+
+      if (condition !== undefined)
+        cursorRequest = objectStore.openCursor(condition);
+      else
+        cursorRequest = objectStore.openCursor();
 
       cursorRequest.onsuccess = function(event) {
         var cursor = event.target.result;

--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -576,6 +576,22 @@ var dbHandler = {
     return request;
   },
 
+  processAllItems: function(storeName, callbackAction) {
+    return new Promise(function(resolve, reject) {
+      var objectStore = DB.transaction(storeName, "readwrite").objectStore(storeName);
+
+      objectStore.openCursor().onsuccess = function(event) {
+        var cursor = event.target.result;
+        if (cursor) {
+          callbackAction(cursor);
+          cursor.continue();
+        } else {
+          resolve();
+        }
+      };
+    });
+  },
+
   getAllItems: function(storeName) {
     return new Promise(function(resolve, reject) {
       var results = [];

--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -56,7 +56,6 @@ var dbHandler = {
           store = upgradeTransaction.objectStore('foodList');
         }
 
-        // Date object, the last time this item was referenced (edited or added to the diary)
         if (!store.indexNames.contains("dateTime")) store.createIndex('dateTime', 'dateTime', {
           unique: false
         });
@@ -73,25 +72,6 @@ var dbHandler = {
           unique: false
         });
 
-        if (!store.indexNames.contains("image_url")) store.createIndex('image_url', 'image_url', {
-          unique: false
-        });
-
-        // Portion - including unit
-        if (!store.indexNames.contains("portion")) store.createIndex('portion', 'portion', {
-          unique: false
-        });
-
-        // Nutrition - per portion
-        if (!store.indexNames.contains("nutrition")) store.createIndex('nutrition', 'nutrition', {
-          unique: false
-        });
-
-        // Deleted foods are marked as archived
-        if (!store.indexNames.contains("archived")) store.createIndex('archived', 'archived', {
-          unique: false
-        });
-
         //Diary Store - one entry per day
         if (!DB.objectStoreNames.contains("diary")) {
           store = DB.createObjectStore('diary', {
@@ -102,18 +82,7 @@ var dbHandler = {
           store = upgradeTransaction.objectStore('diary');
         }
 
-        // Date object
         if (!store.indexNames.contains("dateTime")) store.createIndex('dateTime', 'dateTime', {
-          unique: false
-        });
-
-        // Stats - weight, etc.
-        if (!store.indexNames.contains("stats")) store.createIndex('stats', 'stats', {
-          unique: false
-        });
-
-        // Items array -- foods, recipes, quick-add, etc.
-        if (!store.indexNames.contains("items")) store.createIndex('items', 'items', {
           unique: false
         });
 
@@ -127,22 +96,15 @@ var dbHandler = {
           store = upgradeTransaction.objectStore('meals');
         }
 
-        // Datetime
         if (!store.indexNames.contains("dateTime")) store.createIndex('dateTime', 'dateTime', {
           unique: false
         });
 
-        // Name
         if (!store.indexNames.contains("name")) store.createIndex('name', 'name', {
           unique: false
         });
 
-        // Items
-        if (!store.indexNames.contains("items")) store.createIndex('items', 'items', {
-          unique: false
-        });
-
-        // Recipes store
+        //Recipes store
         if (!DB.objectStoreNames.contains("recipes")) {
           store = DB.createObjectStore("recipes", {
             keyPath: 'id',
@@ -157,11 +119,6 @@ var dbHandler = {
         });
 
         if (!store.indexNames.contains("name")) store.createIndex('name', 'name', {
-          unique: false
-        });
-
-        // Items
-        if (!store.indexNames.contains("items")) store.createIndex('items', 'items', {
           unique: false
         });
 

--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -24,7 +24,7 @@ var dbHandler = {
     return new Promise(async function(resolve, reject) {
       //Open database
       var databaseName = 'waistlineDb';
-      var databaseVersion = 31;
+      var databaseVersion = 32;
       var openRequest = indexedDB.open(databaseName, databaseVersion);
 
       //Error handler
@@ -72,6 +72,11 @@ var dbHandler = {
           unique: false
         });
 
+        if (!store.indexNames.contains("categories")) store.createIndex('categories', 'categories', {
+          unique: false,
+          multiEntry: true
+        });
+
         //Diary Store - one entry per day
         if (!DB.objectStoreNames.contains("diary")) {
           store = DB.createObjectStore('diary', {
@@ -104,6 +109,11 @@ var dbHandler = {
           unique: false
         });
 
+        if (!store.indexNames.contains("categories")) store.createIndex('categories', 'categories', {
+          unique: false,
+          multiEntry: true
+        });
+
         //Recipes store
         if (!DB.objectStoreNames.contains("recipes")) {
           store = DB.createObjectStore("recipes", {
@@ -120,6 +130,11 @@ var dbHandler = {
 
         if (!store.indexNames.contains("name")) store.createIndex('name', 'name', {
           unique: false
+        });
+
+        if (!store.indexNames.contains("categories")) store.createIndex('categories', 'categories', {
+          unique: false,
+          multiEntry: true
         });
 
         await dbHandler.upgradeDatabase(e.oldVersion, upgradeTransaction);

--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2018, 2021 David Healey
+  Copyright 2018, 2019, 2020, 2021 David Healey
 
   This file is part of Waistline.
 

--- a/www/assets/js/db-handler.js
+++ b/www/assets/js/db-handler.js
@@ -548,11 +548,12 @@ var dbHandler = {
     return request;
   },
 
-  processAllItems: function(storeName, callbackAction) {
+  processItems: function(storeName, index, condition, callbackAction) {
     return new Promise(function(resolve, reject) {
-      var objectStore = DB.transaction(storeName, "readwrite").objectStore(storeName);
+      var objectStore = DB.transaction(storeName, "readwrite").objectStore(storeName).index(index);
+      var cursorRequest = objectStore.openCursor(condition);
 
-      objectStore.openCursor().onsuccess = function(event) {
+      cursorRequest.onsuccess = function(event) {
         var cursor = event.target.result;
         if (cursor) {
           callbackAction(cursor);

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -98,7 +98,10 @@ app.Utils = {
 
     let result;
 
-    if (unit1 == unit2)
+    if (value == undefined)
+      result = undefined;
+
+    else if (unit1 == unit2)
       result = value;
 
     // lb/kg

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -1,3 +1,22 @@
+/*
+  Copyright 2018, 2019, 2020, 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Waistline.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 app.Utils = {
 
   tidyText: function(text, maxLength) {

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -57,7 +57,8 @@
     "lb": "lb",
     "st": "st",
     "cm": "cm",
-    "inch": "in"
+    "inch": "in",
+    "feet/inches": "ft/in"
   },
   "dialogs": {
     "delete": "Delete",
@@ -142,6 +143,7 @@
     "quick-add": "Quick Add",
     "yesterdays-meal": "Yesterday's %s",
     "log-title": "Today's Stats",
+    "log-saved": "Saved",
     "no-data": "No Data",
     "default-meals": {
       "breakfast": "Breakfast",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -261,7 +261,11 @@
       "show-notes": "Show Food Notes"
     },
     "foods-categories": {
-      "title": "Labels and Categories"
+      "title": "Labels and Categories",
+      "label": "Label / Icon",
+      "description": "Description",
+      "add": "Add Category",
+      "edit": "Edit Category"
     },
     "statistics": {
       "title": "Statistics",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -50,6 +50,8 @@
   "unit-symbols": {
     "kcal": "kcal",
     "kJ": "kJ",
+    "l": "l",
+    "ml": "ml",
     "g": "g",
     "mg": "mg",
     "µg": "µg",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -254,6 +254,7 @@
       "sort": "Sort Foods",
       "sort-date": "By last used",
       "sort-alpha": "Alphabetically",
+      "category-labels": "Show Category Labels",
       "thumbnails": "Show Thumbnails",
       "wifi-thumbnails": "Only show thumbnails over Wi-Fi",
       "images": "Show Food Images",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -260,6 +260,9 @@
       "wifi-images": "Only show images over Wi-Fi",
       "show-notes": "Show Food Notes"
     },
+    "foods-categories": {
+      "title": "Labels and Categories"
+    },
     "statistics": {
       "title": "Statistics",
       "y-zero": "Begin Y Axis at Zero",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -174,6 +174,7 @@
     "add-new-item": "Add New Item",
     "details": "Details",
     "barcode": "Barcode",
+    "categories": "Categories",
     "name": "Name",
     "brand": "Brand",
     "category": "Category",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -244,7 +244,11 @@
       "prompt-add-items": "Prompt for quantity when adding items"
     },
     "nutriments": {
-      "title": "Nutriments"
+      "title": "Nutriments",
+      "field": "Name",
+      "unit": "Unit",
+      "add": "Add Field",
+      "edit": "Edit Field"
     },
     "diary-categories": {
       "title": "Categories",

--- a/www/index.html
+++ b/www/index.html
@@ -135,6 +135,7 @@
   <script src="activities/recipes/js/recipes.js"></script>
   <script src="activities/recipes/js/recipe-editor.js"></script>
   <script src="activities/settings/js/settings.js"></script>
+  <script src="activities/settings/js/nutriments.js"></script>
   <script src="activities/settings/js/foods-categories.js"></script>
   <script src="activities/setup-wizard/js/setup-wizard.js"></script>
 </body>

--- a/www/index.html
+++ b/www/index.html
@@ -135,6 +135,7 @@
   <script src="activities/recipes/js/recipes.js"></script>
   <script src="activities/recipes/js/recipe-editor.js"></script>
   <script src="activities/settings/js/settings.js"></script>
+  <script src="activities/settings/js/foods-categories.js"></script>
   <script src="activities/setup-wizard/js/setup-wizard.js"></script>
 </body>
 

--- a/www/index.js
+++ b/www/index.js
@@ -238,7 +238,14 @@ const app = {
             url: "activities/settings/views/foods.html",
             options: {
               transition: "f7-parallax"
-            }
+            },
+            routes: [{
+              path: "categories/",
+              url: "activities/settings/views/foods-categories.html",
+              options: {
+                transition: "f7-parallax"
+              },
+            }]
           },
           {
             path: "units/",


### PR DESCRIPTION
This PR adds support for food categories/labels and custom nutriment fields. This was quite some work and I'm not sure if all the features are 100% working correctly yet, so we should make sure to test this thoroughly before the next release.

### Food categories

Closes #328, closes #408.

The user can add, edit, delete and reorder categories and labels in settings:

![Screenshot_20211217-112330](https://user-images.githubusercontent.com/19289477/146531106-0b126aeb-3821-42b9-9092-9b199a7d6e0e.jpg) ![Screenshot_20211217-112343](https://user-images.githubusercontent.com/19289477/146531107-caf203fd-68e8-4b7b-aa67-d7a05e268059.jpg)

The categories can be applied to any food, meal or recipe item from a dropdown menu in the editor page:

![Screenshot_20211217-112505](https://user-images.githubusercontent.com/19289477/146531111-d9a9baa4-2709-41e2-b672-6b6773572ef5.jpg)

When searching locally, the user can filter by category by tapping the icon in the search bar (long pressing the icon resets the filter):

![Screenshot_20211217-112412](https://user-images.githubusercontent.com/19289477/146531108-ee21993f-11dc-4258-acd2-c3a79bd6ef50.jpg)

### Custom fields

On the nutriment settings page, the user can now add (also edit and delete) their own fields. The feature can be used for custom nutriments or workouts or whatever. This should be sufficient to resolve #384.

![Screenshot_20211217-112842](https://user-images.githubusercontent.com/19289477/146531112-64fe8606-e131-4444-a14a-a63956318639.jpg)
