### PR TITLE
Stats page swipe gestures

### DIFF
--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -106,11 +106,51 @@ app.Stats = {
 
           app.Stats.chart.destroy();
           app.Stats.chart = undefined;
-          this.updateChart(app.Stats.el.stat.value);
+          app.Stats.updateChart();
         });
         x.hasClickEvent = true;
       }
     });
+
+    // Dropdown swipe events
+    app.Stats.el.range.addEventListener("touchstart", (e) => {
+      touchstartX = e.changedTouches[0].screenX;
+    }, false);
+
+    app.Stats.el.stat.addEventListener("touchstart", (e) => {
+      touchstartX = e.changedTouches[0].screenX;
+    }, false);
+
+    app.Stats.el.range.addEventListener("touchend", (e) => {
+      touchendX = e.changedTouches[0].screenX;
+      app.Stats.handleSwipeGesture(app.Stats.el.range);
+    }, false);
+
+    app.Stats.el.stat.addEventListener("touchend", (e) => {
+      touchendX = e.changedTouches[0].screenX;
+      app.Stats.handleSwipeGesture(app.Stats.el.stat);
+    }, false);
+  },
+
+  handleSwipeGesture: function(select) {
+    const buffer = 50;
+    const event = new Event("change");
+
+    // Swiped right
+    if (touchendX > touchstartX + buffer) {
+      if (select.selectedIndex < select.length - 1) {
+        select.selectedIndex += 1;
+        select.dispatchEvent(event);
+      }
+    }
+
+    // Swiped left
+    if (touchendX + buffer < touchstartX) {
+      if (select.selectedIndex > 0) {
+        select.selectedIndex -= 1;
+        select.dispatchEvent(event);
+      }
+    }
   },
 
   setChartTypeButtonVisibility: function() {

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -134,22 +134,35 @@ app.Stats = {
 
   handleSwipeGesture: function(select) {
     const buffer = 50;
-    const event = new Event("change");
 
     // Swiped right
     if (touchendX > touchstartX + buffer) {
-      if (select.selectedIndex < select.length - 1) {
-        select.selectedIndex += 1;
-        select.dispatchEvent(event);
-      }
+      if ($("html").get(0).getAttribute("dir") === "rtl")
+        app.Stats.selectNext(select);
+      else
+        app.Stats.selectPrevious(select);
     }
 
     // Swiped left
     if (touchendX + buffer < touchstartX) {
-      if (select.selectedIndex > 0) {
-        select.selectedIndex -= 1;
-        select.dispatchEvent(event);
-      }
+      if ($("html").get(0).getAttribute("dir") === "rtl")
+        app.Stats.selectPrevious(select);
+      else
+        app.Stats.selectNext(select);
+    }
+  },
+
+  selectNext: function(select) {
+    if (select.selectedIndex < select.length - 1) {
+      select.selectedIndex += 1;
+      select.dispatchEvent(new Event("change"));
+    }
+  },
+
+  selectPrevious: function(select) {
+    if (select.selectedIndex > 0) {
+      select.selectedIndex -= 1;
+      select.dispatchEvent(new Event("change"));
     }
   },
 


### PR DESCRIPTION
This PR adds swipe gestures to the dropdown menus on the Statistics page. By swiping left or right, the user can quickly cycle through the list of nutrients and also select a date range more easily.