### PR TITLE
Show food thumbnails in meal and recipe editor

### DIFF
--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -73,10 +73,10 @@ app.Group = {
     innerList.appendChild(innerUl);
 
     // Render items
-    let showTimestamp = app.Settings.get("diary", "timestamps");
-    let showThumbnail = app.Utils.showThumbnails("diary");
+    let showTimestamps = app.Settings.get("diary", "timestamps");
+    let showThumbnails = app.Utils.showThumbnails("diary");
     this.items.forEach((x) => {
-      app.FoodsMealsRecipes.renderItem(x, innerUl, false, undefined, self.removeItem, undefined, showTimestamp, showThumbnail);
+      app.FoodsMealsRecipes.renderItem(x, innerUl, false, undefined, self.removeItem, undefined, showTimestamps, showThumbnails);
     });
 
     let nutrition = await app.FoodsMealsRecipes.getTotalNutrition(this.items);

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -148,6 +148,7 @@ app.Foodlist = {
     let maxItems = 300; // Max items to load
     let itemsPerLoad = 20; // Number of items to append at a time
     let lastIndex = document.querySelectorAll(".page[data-name='foods-meals-recipes'] #foodlist-container li").length;
+    let showThumbnails = app.Utils.showThumbnails("foodlist");
 
     if (lastIndex <= app.Foodlist.list.length) {
       //Render next set of items to list
@@ -158,8 +159,7 @@ app.Foodlist = {
 
         if (item != undefined) {
           item.type = "food";
-          let showThumbnail = app.Utils.showThumbnails("foodlist");
-          app.FoodsMealsRecipes.renderItem(item, app.Foodlist.el.list, true, undefined, this.removeItem, undefined, false, showThumbnail);
+          app.FoodsMealsRecipes.renderItem(item, app.Foodlist.el.list, true, undefined, this.removeItem, undefined, false, showThumbnails);
         }
       }
     }

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -235,9 +235,11 @@ app.MealEditor = {
       app.MealEditor.el.foodlist.innerHTML = "";
       app.FoodsMealsRecipes.disableEdit = false;
 
+      let showThumbnails = app.Utils.showThumbnails("foodlist");
+
       app.MealEditor.meal.items.forEach(async (x, i) => {
         x.index = i;
-        app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, undefined, app.MealEditor.removeItem);
+        app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, undefined, app.MealEditor.removeItem, undefined, false, showThumbnails);
       });
 
       resolve();

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -239,9 +239,11 @@ app.RecipeEditor = {
       app.RecipeEditor.el.foodlist.innerHTML = "";
       app.FoodsMealsRecipes.disableEdit = false;
 
+      let showThumbnails = app.Utils.showThumbnails("foodlist");
+
       app.RecipeEditor.recipe.items.forEach(async (x, i) => {
         x.index = i;
-        app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, undefined, app.RecipeEditor.removeItem);
+        app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, undefined, app.RecipeEditor.removeItem, undefined, false, showThumbnails);
       });
 
       resolve();


### PR DESCRIPTION
Currently, the option `Settings > Foods, Meals, Recipes > Show Thumbnails` only applies to the food list. With the changes in this PR, the option now also applies to the meal and recipe editor. In other words, if the option is enabled, Waistline shows thumbnails for ingredients in the meal and recipe editor.

![thumbmails](https://user-images.githubusercontent.com/19289477/149658353-c7d1dffb-4663-44d2-a669-6e689fcbb5db.png)
