### PR TITLE
Option to show more/all nutriments

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -59,6 +59,7 @@ app.DiaryChart = {
       const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
       const units = app.Nutriments.getNutrimentUnits();
       const visible = app.Settings.getField("nutrimentVisibility");
+      const showAll = app.Settings.get("diary", "show-all-nutriments");
 
       let result = {
         "labels": [],
@@ -126,7 +127,7 @@ app.DiaryChart = {
       // Totals
       nutriments.forEach((x) => {
         if (x == "calories" || x == "kilojoules") return;
-        if (!visible[x]) return;
+        if (showAll !== true && visible[x] !== true) return;
         if (!nutrition[x]) return;
 
         let name = app.strings.nutriments[x] || x;

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -738,6 +738,7 @@ app.Diary = {
     const units = app.Nutriments.getNutrimentUnits();
     const energyUnit = app.Settings.get("units", "energy");
     const visible = app.Settings.getField("nutrimentVisibility");
+    const showAll = app.Settings.get("diary", "show-all-nutriments");
 
     // Create dialog
     let div = document.createElement("div");
@@ -753,7 +754,7 @@ app.Diary = {
       if (x == "calories" || x == "kilojoules") {
         if (units[x] != energyUnit) continue;
       } else {
-        if (!visible[x]) continue;
+        if (showAll !== true && visible[x] !== true) continue;
       }
 
       // Get name, unit and value

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -95,6 +95,7 @@ app.FoodEditor = {
     app.FoodEditor.el.notes = document.querySelector(".page[data-name='food-editor'] #notes");
     app.FoodEditor.el.notesContainer = document.querySelector(".page[data-name='food-editor'] #notes-container");
     app.FoodEditor.el.nutrition = document.querySelector(".page[data-name='food-editor'] #nutrition");
+    app.FoodEditor.el.nutritionButton = document.querySelector(".page[data-name='food-editor'] #nutrition-button");
     app.FoodEditor.el.mainPhoto = document.querySelector(".page[data-name='food-editor'] #main-photo");
     app.FoodEditor.el.addPhoto = Array.from(document.getElementsByClassName("add-photo"));
     app.FoodEditor.el.photoHolder = Array.from(document.getElementsByClassName("photo-holder"));
@@ -138,6 +139,14 @@ app.FoodEditor = {
         app.f7.views.main.router.navigate("/foods-meals-recipes/");
       });
       app.FoodEditor.el.upload.hasClickEvent = true;
+    }
+
+    // Nutrition fields visibility toggle button
+    if (!app.FoodEditor.el.nutritionButton.hasClickEvent) {
+      app.FoodEditor.el.nutritionButton.addEventListener("click", async (e) => {
+        app.FoodsMealsRecipes.toggleNutritionFieldsVisibility(app.FoodEditor.el.nutrition, app.FoodEditor.el.nutritionButton);
+      });
+      app.FoodEditor.el.nutritionButton.hasClickEvent = true;
     }
 
     // Add-photo
@@ -267,8 +276,6 @@ app.FoodEditor = {
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
     const units = app.Nutriments.getNutrimentUnits();
-    const energyUnit = app.Settings.get("units", "energy");
-    const visible = app.Settings.getField("nutrimentVisibility");
 
     if (item !== undefined && item.nutrition.kilojoules == undefined)
       item.nutrition.kilojoules = app.Utils.convertUnit(item.nutrition.calories, units.calories, units.kilojoules);
@@ -284,9 +291,6 @@ app.FoodEditor = {
 
         let name = app.strings.nutriments[k] || k;
         let unit = app.strings["unit-symbols"][units[k]] || units[k];
-
-        if (visible[k] !== true && units[k] !== energyUnit)
-          li.style.display = "none";
 
         ul.appendChild(li);
 
@@ -307,7 +311,7 @@ app.FoodEditor = {
 
         let input = document.createElement("input");
         input.id = k;
-        input.className = "align-end auto-select";
+        input.className = "nutrition-field align-end auto-select";
         input.type = "number";
         input.step = "0.01";
         input.placeholder = "0";
@@ -341,6 +345,8 @@ app.FoodEditor = {
         inputWrapper.appendChild(input);
       }
     }
+
+    app.FoodsMealsRecipes.setNutritionFieldsVisibility(app.FoodEditor.el.nutrition, app.FoodEditor.el.nutritionButton, false);
   },
 
   populateCategoryField: function(item) {

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -731,6 +731,45 @@ app.FoodsMealsRecipes = {
       default:
     }
   },
+
+  toggleNutritionFieldsVisibility: function(listEl, button) {
+    if (button.state === "show-less") {
+      app.FoodsMealsRecipes.setNutritionFieldsVisibility(listEl, button, false);
+      button.state = "show-more";
+      button.innerText = app.strings["foods-meals-recipes"]["show-more-nutriments"] || "Show more nutriments";
+    } else {
+      app.FoodsMealsRecipes.setNutritionFieldsVisibility(listEl, button, true);
+      button.state = "show-less";
+      button.innerText = app.strings["foods-meals-recipes"]["show-less-nutriments"] || "Show less nutriments";
+    }
+  },
+
+  setNutritionFieldsVisibility: function(listEl, button, showAll) {
+    const units = app.Nutriments.getNutrimentUnits();
+    const energyUnit = app.Settings.get("units", "energy");
+    const visible = app.Settings.getField("nutrimentVisibility");
+
+    let allFieldsVisible = true;
+
+    listEl.childNodes.forEach((li) => {
+      let field = li.querySelectorAll(".nutrition-field")[0];
+
+      if (field !== undefined && field.id !== undefined) {
+        let nutriment = field.id;
+
+        if (visible[nutriment] !== true && units[nutriment] !== energyUnit)
+          allFieldsVisible = false;
+
+        if (showAll === true || visible[nutriment] === true || units[nutriment] === energyUnit)
+          li.style.display = "block";
+        else
+          li.style.display = "none";
+      }
+    });
+
+    if (allFieldsVisible)
+      button.style.display = "none";
+  }
 };
 
 document.addEventListener("page:init", function(e) {

--- a/www/activities/foods-meals-recipes/views/food-editor.html
+++ b/www/activities/foods-meals-recipes/views/food-editor.html
@@ -212,6 +212,10 @@
             <ul id="nutrition">
             </ul>
 
+            <ul>
+              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutriments</a></li>
+            </ul>
+
           </div>
         </li>
 

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -59,6 +59,7 @@ app.MealEditor = {
     app.MealEditor.el.foodlist = document.querySelector(".page[data-name='meal-editor'] #meal-food-list");
     app.MealEditor.el.add = document.querySelector(".page[data-name='meal-editor'] #add-food");
     app.MealEditor.el.nutrition = document.querySelector(".page[data-name='meal-editor'] #nutrition");
+    app.MealEditor.el.nutritionButton = document.querySelector(".page[data-name='meal-editor'] #nutrition-button");
   },
 
   setComponentVisibility: function() {
@@ -88,6 +89,14 @@ app.MealEditor = {
         });
       });
       app.MealEditor.el.add.hasClickEvent = true;
+    }
+
+    // Nutrition fields visibility toggle button
+    if (!app.MealEditor.el.nutritionButton.hasClickEvent) {
+      app.MealEditor.el.nutritionButton.addEventListener("click", async (e) => {
+        app.FoodsMealsRecipes.toggleNutritionFieldsVisibility(app.MealEditor.el.nutrition, app.MealEditor.el.nutritionButton);
+      });
+      app.MealEditor.el.nutritionButton.hasClickEvent = true;
     }
   },
 
@@ -193,8 +202,6 @@ app.MealEditor = {
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
     const units = app.Nutriments.getNutrimentUnits();
-    const energyUnit = app.Settings.get("units", "energy");
-    const visible = app.Settings.getField("nutrimentVisibility");
 
     const ul = app.MealEditor.el.nutrition;
     ul.innerHTML = "";
@@ -202,8 +209,6 @@ app.MealEditor = {
     nutriments.forEach((x) => {
 
       if (nutrition[x] == undefined || nutrition[x] == 0) return;
-      if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) return;
-      if (visible[x] !== true && !["calories", "kilojoules"].includes(x)) return;
 
       let unit = app.strings["unit-symbols"][units[x]] || units[x];
 
@@ -224,10 +229,13 @@ app.MealEditor = {
       innerDiv.appendChild(title);
 
       let after = document.createElement("div");
-      after.className = "item-after";
+      after.className = "item-after nutrition-field";
+      after.id = x;
       after.innerText = Math.round(nutrition[x] * 100) / 100;
       innerDiv.appendChild(after);
     });
+
+    app.FoodsMealsRecipes.setNutritionFieldsVisibility(ul, app.MealEditor.el.nutritionButton, false);
   },
 
   renderItems: function() {

--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -100,6 +100,9 @@
           <div class="accordion-item-content inline-labels">
             <ul id="nutrition">
             </ul>
+            <ul>
+              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutriments</a></li>
+            </ul>
           </div>
         </li>
       </ul>

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -60,6 +60,7 @@ app.RecipeEditor = {
     app.RecipeEditor.el.foodlist = document.querySelector(".page[data-name='recipe-editor'] #recipe-food-list");
     app.RecipeEditor.el.add = document.querySelector(".page[data-name='recipe-editor'] #add-food");
     app.RecipeEditor.el.nutrition = document.querySelector(".page[data-name='recipe-editor'] #nutrition");
+    app.RecipeEditor.el.nutritionButton = document.querySelector(".page[data-name='recipe-editor'] #nutrition-button");
   },
 
   setComponentVisibility: function() {
@@ -89,6 +90,14 @@ app.RecipeEditor = {
         });
       });
       app.RecipeEditor.el.add.hasClickEvent = true;
+    }
+
+    // Nutrition fields visibility toggle button
+    if (!app.RecipeEditor.el.nutritionButton.hasClickEvent) {
+      app.RecipeEditor.el.nutritionButton.addEventListener("click", async (e) => {
+        app.FoodsMealsRecipes.toggleNutritionFieldsVisibility(app.RecipeEditor.el.nutrition, app.RecipeEditor.el.nutritionButton);
+      });
+      app.RecipeEditor.el.nutritionButton.hasClickEvent = true;
     }
   },
 
@@ -197,8 +206,6 @@ app.RecipeEditor = {
 
     const nutriments = app.Settings.get("nutriments", "order") || app.nutriments;
     const units = app.Nutriments.getNutrimentUnits();
-    const energyUnit = app.Settings.get("units", "energy");
-    const visible = app.Settings.getField("nutrimentVisibility");
 
     const ul = app.RecipeEditor.el.nutrition;
     ul.innerHTML = "";
@@ -206,8 +213,6 @@ app.RecipeEditor = {
     nutriments.forEach((x) => {
 
       if (nutrition[x] == undefined || nutrition[x] == 0) return;
-      if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) return;
-      if (visible[x] !== true && !["calories", "kilojoules"].includes(x)) return;
 
       let unit = app.strings["unit-symbols"][units[x]] || units[x];
 
@@ -228,10 +233,13 @@ app.RecipeEditor = {
       innerDiv.appendChild(title);
 
       let after = document.createElement("div");
-      after.className = "item-after";
+      after.className = "item-after nutrition-field";
+      after.id = x;
       after.innerText = Math.round(nutrition[x] * 100) / 100;
       innerDiv.appendChild(after);
     });
+
+    app.FoodsMealsRecipes.setNutritionFieldsVisibility(ul, app.RecipeEditor.el.nutritionButton, false);
   },
 
   renderItems: function() {

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -127,6 +127,9 @@
           <div class="accordion-item-content inline-labels">
             <ul id="nutrition">
             </ul>
+            <ul>
+              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutriments</a></li>
+            </ul>
           </div>
         </li>
       </ul>

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -361,6 +361,7 @@ app.Settings = {
         timestamps: false,
         "show-thumbnails": false,
         "wifi-thumbnails": true,
+        "show-all-nutriments": false,
         "show-nutrition-units": false,
         "prompt-add-items": false
       },

--- a/www/activities/settings/views/diary.html
+++ b/www/activities/settings/views/diary.html
@@ -84,6 +84,20 @@
         <li>
           <div class="item-content">
             <div class="item-inner">
+              <div class="item-title" data-localize="settings.diary.show-all-nutriments">Show all nutriments on Overview page</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="diary" name="show-all-nutriments" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
               <div class="item-title" data-localize="settings.diary.show-units">Show nutrition units</div>
               <div class="item-after">
                 <label class="toggle toggle-init">

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -170,7 +170,9 @@
     "recipes": "Recipes",
     "selected": "Selected",
     "search": "Search",
-    "scan-prompt": "Place a barcode inside the scan area"
+    "scan-prompt": "Place a barcode inside the scan area",
+    "show-more-nutriments": "Show more nutriments",
+    "show-less-nutriments": "Show less nutriments"
   },
   "food-editor": {
     "edit-item": "Edit Item",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -243,6 +243,7 @@
       "timestamps": "Show Timestamps",
       "thumbnails": "Show Thumbnails",
       "wifi-thumbnails": "Only show thumbnails over Wi-Fi",
+      "show-all-nutriments": "Show all nutriments on Overview page",
       "show-units": "Show nutrition units",
       "prompt-add-items": "Prompt for quantity when adding items"
     },


### PR DESCRIPTION
This adds an option to show all nutriments on the Diary Overview page instead of just showing the tracked ones (by tracked nutriments I mean those which are enabled in settings).

Also, it adds a toggle button in the food editor to temporarily show all nutrition fields instead of just the tracked ones:

![show_more](https://user-images.githubusercontent.com/19289477/149658392-545e93ce-d54d-488b-8247-856d0f9d040e.png) ![show_less](https://user-images.githubusercontent.com/19289477/149658723-ec8a4c7e-3019-4233-8f97-33cdb4070a49.png)

