### PR TITLE
Add setting for First Day of Week and Average Goal Base

### DIFF
--- a/www/activities/goals/js/goal-editor.js
+++ b/www/activities/goals/js/goal-editor.js
@@ -68,7 +68,6 @@ app.GoalEditor = {
     app.GoalEditor.el.autoAdjust = document.querySelector(".page[data-name='goal-editor'] #auto-adjust");
     app.GoalEditor.el.minimumGoal = document.querySelector(".page[data-name='goal-editor'] #minimum-goal");
     app.GoalEditor.el.percentGoal = document.querySelector(".page[data-name='goal-editor'] #percent-goal");
-    app.GoalEditor.el.primaryGoal = document.querySelector(".page[data-name='goal-editor'] #primary-goal");
   },
 
   bindUIActions: function() {
@@ -134,13 +133,17 @@ app.GoalEditor = {
       app.GoalEditor.el.autoAdjustOption.style.display = "none";
       app.GoalEditor.el.minimumGoalOption.style.display = "none";
       app.GoalEditor.el.percentGoalOption.style.display = "none";
-      app.GoalEditor.el.primaryGoal.innerText = app.strings["goal-editor"]["goal"] || "Goal";
+      document.querySelector(".page[data-name='goal-editor'] #goal-0").innerText = app.strings["goal-editor"]["goal"] || "Goal";
       const extraGoals = Array.from(document.querySelectorAll("li.extra-goal"));
       extraGoals.forEach((x) => {
         x.style.display = "none";
       });
     } else {
-      app.GoalEditor.el.primaryGoal.innerText = app.strings["days"]["0"] || "Sunday";
+      const firstDayOfWeek = app.Settings.get("goals", "first-day-of-week") || 0;
+      for (let i = 0; i < 7; i++) {
+        const d = (Number(firstDayOfWeek) + i) % 7;
+        document.querySelector(".page[data-name='goal-editor'] #goal-" + i).innerText = app.strings["days"][d] || d;
+      }
       if (!app.energyMacroNutriments.includes(app.GoalEditor.stat))
         app.GoalEditor.el.percentGoalOption.style.display = "none";
     }

--- a/www/activities/goals/views/goal-editor.html
+++ b/www/activities/goals/views/goal-editor.html
@@ -78,7 +78,7 @@
         <li id="adjust">
           <div class="item-content">
             <div class="item-inner">
-              <div class="item-title" data-localize="goal-editor.auto-adjust">Auto adjust to meet weekly goal</div>
+              <div class="item-title" data-localize="goal-editor.auto-adjust">Auto adjust to meet average goal</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
                   <input type="checkbox" class="manual-bind" id="auto-adjust" field="goals" />
@@ -121,7 +121,7 @@
         <li>
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" id="primary-goal">Sunday</div>
+              <div class="item-title item-label" id="goal-0">Sunday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>
@@ -132,7 +132,7 @@
         <li class="extra-goal">
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" data-localize="days.1">Monday</div>
+              <div class="item-title item-label" id="goal-1">Monday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>
@@ -143,7 +143,7 @@
         <li class="extra-goal">
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" data-localize="days.2">Tuesday</div>
+              <div class="item-title item-label" id="goal-2">Tuesday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>
@@ -154,7 +154,7 @@
         <li class="extra-goal">
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" data-localize="days.3">Wednesday</div>
+              <div class="item-title item-label" id="goal-3">Wednesday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>
@@ -165,7 +165,7 @@
         <li class="extra-goal">
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" data-localize="days.4">Thursday</div>
+              <div class="item-title item-label" id="goal-4">Thursday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>
@@ -176,7 +176,7 @@
         <li class="extra-goal">
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" data-localize="days.5">Friday</div>
+              <div class="item-title item-label" id="goal-5">Friday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>
@@ -187,7 +187,7 @@
         <li class="extra-goal">
           <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title item-label" data-localize="days.6">Saturday</div>
+              <div class="item-title item-label" id="goal-6">Saturday</div>
               <div class="item-input-wrap">
                 <input type="number" min="0" step="any" field="goals">
               </div>

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -19,7 +19,7 @@
 
 // After a breaking change to the settings schema, increment this constant
 // and implement the migration in the migrateSettings() function below
-const currentSettingsSchemaVersion = 3;
+const currentSettingsSchemaVersion = 4;
 
 var s;
 app.Settings = {
@@ -397,6 +397,8 @@ app.Settings = {
         length: "cm"
       },
       goals: {
+        "first-day-of-week": "0",
+        "average-goal-base": "week",
         calories: ["2000", "", "", "", "", "", ""],
         "calories-shared-goal": true,
         "calories-show-in-diary": true,
@@ -458,6 +460,12 @@ app.Settings = {
       if (settings.foodlist !== undefined && settings.foodlist.labels === undefined && settings.foodlist.categories === undefined) {
         settings.foodlist.labels = app.FoodsCategories.defaultLabels;
         settings.foodlist.categories = app.FoodsCategories.defaultCategories;
+      }
+
+      // First Day of Week and Average Base settings must be added
+      if (settings.goals !== undefined && settings.goals["first-day-of-week"] === undefined && settings.goals["average-goal-base"] === undefined) {
+        settings.goals["first-day-of-week"] = "0";
+        settings.goals["average-goal-base"] = "week";
       }
 
       settings.schemaVersion = currentSettingsSchemaVersion;

--- a/www/activities/settings/views/goals.html
+++ b/www/activities/settings/views/goals.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div class="page" data-name="settings-goals">
+
+  <div class="navbar">
+    <div class="navbar-bg"></div>
+    <div class="navbar-inner">
+      <div class="left"><a class="link back"><i class="icon icon-back"></i></a></div>
+      <div class="title" data-localize="settings.goals.title">Goals</div>
+      <div class="right"></div>
+    </div>
+  </div>
+
+  <div class="page-content">
+    <div class="list">
+      <ul>
+        <li>
+          <div class="item-content item-input">
+            <div class="item-inner">
+              <div class="item-title item-label" data-localize="settings.goals.first-day-of-week">First day of the week</div>
+              <div class="item-input-wrap input-dropdown-wrap">
+                <select name="first-day-of-week" field="goals">
+                  <option value="0" selected data-localize="days.0">Sunday</option>
+                  <option value="1" data-localize="days.1">Monday</option>
+                  <option value="2" data-localize="days.2">Tuesday</option>
+                  <option value="3" data-localize="days.3">Wednesday</option>
+                  <option value="4" data-localize="days.4">Thursday</option>
+                  <option value="5" data-localize="days.5">Friday</option>
+                  <option value="6" data-localize="days.6">Saturday</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div class="item-content item-input">
+            <div class="item-inner">
+              <div class="item-title item-label" data-localize="settings.goals.average-goal-base">Compute average goals based on</div>
+              <div class="item-input-wrap input-dropdown-wrap">
+                <select name="average-goal-base" field="goals">
+                  <option value="week" selected data-localize="settings.goals.current-week">Current Week</option>
+                  <option value="3-days" data-localize="settings.goals.last-3-days">Last 3 Days</option>
+                  <option value="5-days" data-localize="settings.goals.last-5-days">Last 5 Days</option>
+                  <option value="7-days" data-localize="settings.goals.last-7-days">Last 7 Days</option>
+                  <option value="10-days" data-localize="settings.goals.last-10-days">Last 10 Days</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/www/activities/settings/views/settings.html
+++ b/www/activities/settings/views/settings.html
@@ -60,6 +60,12 @@
         </li>
 
         <li>
+          <a href="./goals/" class="item-link item-content">
+            <div class="item-inner" data-localize="settings.goals.title">Goals</div>
+          </a>
+        </li>
+
+        <li>
           <a href="./units/" class="item-link item-content">
             <div class="item-inner" data-localize="settings.units.title">Units</div>
           </a>

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -335,7 +335,11 @@ app.Stats = {
 
         if (value != undefined && value != 0 && !isNaN(value)) {
           let timestamp = data.timestamps[i];
-          let date = new Intl.DateTimeFormat('en-GB').format(timestamp);
+          let date = timestamp.toLocaleDateString([], {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit"
+          });
           result.dates.push(date);
           result.dataset.values.push(Math.round(value * 100) / 100);
           result.average = result.average + value;

--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -1,3 +1,22 @@
+/*
+  Copyright 2018, 2019, 2020, 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 .align-end {text-align: end; padding: 0 0.4em !important;}
 * {-webkit-touch-callout: none; -webkit-user-select: none; -khtml-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;}
 input {-webkit-touch-callout: default !important; -webkit-user-select: auto !important; -khtml-user-select: auto !important; -moz-user-select: auto !important; -ms-user-select: auto !important; user-select: auto !important;}
@@ -17,11 +36,11 @@ i.searchbar-icon {margin: -12px 12px;}
 
 .item-content.item-inner {column-gap: 0.8em;}
 
-#food-edit-form div.item-title {width:32vw;}
-#meal-edit-form div.item-title {width:32vw;}
-#recipe-edit-form div.item-title {width:32vw;}
-#quantity-container div.item-title {width:60vw;}
-#nutrition div.item-title {width:60vw;}
+#food-edit-form .item-input .item-title {width: 32vw;}
+#meal-edit-form .item-input .item-title {width: 32vw;}
+#recipe-edit-form .item-input .item-title {width: 32vw;}
+#quantity-container.item-input .item-title {width: 60vw;}
+#nutrition .item-input .item-title {width: 60vw;}
 
 img.food-thumbnail {width: 20%; margin: 0.2em 1em 0.2em 0;}
 html[dir="rtl"] img.food-thumbnail {margin: 0.2em 0 0.2em 1em;}

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -260,6 +260,16 @@
       "title": "Categories",
       "category": "Category"
     },
+    "goals": {
+      "title": "Goals",
+      "first-day-of-week": "First day of the week",
+      "average-goal-base": "Compute average goals based on",
+      "current-week": "Current Week",
+      "last-3-days": "Last 3 Days",
+      "last-5-days": "Last 5 Days",
+      "last-7-days": "Last 7 Days",
+      "last-10-days": "Last 10 Days"
+    },
     "foods": {
       "title": "Foods, Meals, Recipes",
       "sort": "Sort Foods",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -205,7 +205,7 @@
     "show-in-diary": "Show in Diary",
     "show-in-stats": "Show in Statistics",
     "shared-goal": "Same goal every day",
-    "auto-adjust": "Auto adjust to meet weekly goal",
+    "auto-adjust": "Auto adjust to meet average goal",
     "minimum-goal": "Is minimum goal",
     "percent-goal": "Goal as percentage of energy intake"
   },

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -99,20 +99,6 @@
     "5": "Friday",
     "6": "Saturday"
   },
-  "months": {
-    "0": "January",
-    "1": "February",
-    "2": "March",
-    "3": "April",
-    "4": "May",
-    "5": "June",
-    "6": "July",
-    "7": "August",
-    "8": "September",
-    "9": "October",
-    "10": "November",
-    "11": "December"
-  },
   "colours": {
     "red": "Red",
     "blue": "Blue",

--- a/www/index.js
+++ b/www/index.js
@@ -250,6 +250,13 @@ const app = {
             }]
           },
           {
+            path: "goals/",
+            url: "activities/settings/views/goals.html",
+            options: {
+              transition: "f7-parallax"
+            }
+          },,
+          {
             path: "units/",
             url: "activities/settings/views/units.html",
             options: {


### PR DESCRIPTION
This adds a setting to choose the first day of the week and to specify how the average goals should be computed. Closes #431.

![Untitled](https://user-images.githubusercontent.com/19289477/150636375-cd971be0-55a1-4e81-a239-dd3dbe2818c2.png)
