### PR TITLE
Improve diary categories

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -246,22 +246,23 @@ app.Diary = {
       values.id = x + "-value";
 
       let span = document.createElement("span");
-      t = document.createTextNode("0");
+      t = document.createTextNode("");
+      let value = 0;
 
       if (nutrition !== undefined && nutrition[x] !== undefined) {
         if (x !== "calories" && x !== "kilojoules")
-          t.nodeValue = app.Utils.tidyNumber(Math.round(nutrition[x] * 100) / 100);
+          value = (Math.round(nutrition[x] * 100) / 100);
         else
-          t.nodeValue = app.Utils.tidyNumber(Math.round(nutrition[x]));
+          value = (Math.round(nutrition[x]));
       }
+      t.nodeValue = app.Utils.tidyNumber(value);
 
       // Set value text colour
-      if (goal !== undefined && goal !== "") {
+      if (goal !== undefined && goal !== "" && !isNaN(goal)) {
 
         let isMin = app.Goals.isMinimumGoal(x);
-        let v = parseFloat(t.nodeValue);
 
-        if ((!isMin && v > goal) || (isMin == true && v < goal))
+        if ((!isMin && value > goal) || (isMin == true && value < goal))
           span.style.color = "red";
         else
           span.style.color = "green";

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -30,25 +30,22 @@ app.Diary = {
     this.getComponents();
     this.bindUIActions();
 
-    //If items have been passed, add them to the db
+    // If items have been passed, add them to the db
     if (context) {
       if (context.items || context.item) {
         if (context.items)
           await this.addItems(context.items, context.category);
         else
           await this.updateItem(context.item);
-
-        app.Diary.ready = false; //Trigger fresh render
       }
     }
 
     if (!app.Diary.ready) {
-      app.Diary.groups = this.createMealGroups(); //Create meal groups
-      this.render();
+      app.Diary.groups = this.createMealGroups(); // Create meal groups
+      app.Diary.render(app.Diary.lastScrollPosition);
       app.Diary.ready = true;
-    } else {
-      app.Diary.lastScrollPosition = 0; // Reset last scroll position
     }
+    app.Diary.lastScrollPosition = 0; // Reset last scroll position
   },
 
   getComponents: function() {
@@ -101,7 +98,7 @@ app.Diary = {
         change: function(c) {
           app.Diary.date = c.getValue();
           if (app.Diary.ready)
-            app.Diary.render();
+            app.Diary.render(0);
           c.close();
           app.Diary.updateDateDisplay();
         }
@@ -111,9 +108,9 @@ app.Diary = {
   },
 
   bindCalendarControls: function() {
-    //Bind actions for previous/next buttons
-    const buttons = document.getElementsByClassName("change-date");
-    Array.from(buttons).forEach((x, i) => {
+    // Bind actions for previous/next buttons
+    const buttons = document.querySelectorAll(".page[data-name='diary'] .change-date");
+    buttons.forEach((x, i) => {
       if (!x.hasClickEvent) {
         x.addEventListener("click", (e) => {
           let date = new Date(app.Diary.calendar.getValue());
@@ -124,8 +121,7 @@ app.Diary = {
       }
     });
 
-    let el = document.querySelector(".page[data-name='diary'] #diary-date");
-
+    const el = document.querySelector(".page[data-name='diary'] #diary-date");
     if (!el.hasClickEvent) {
       el.addEventListener("click", (e) => {
         app.Diary.calendar.open();
@@ -153,7 +149,7 @@ app.Diary = {
     el.innerText = dateString;
   },
 
-  render: async function() {
+  render: async function(scrollPosition) {
     let entry = await this.getEntryFromDB(); // Get diary entry from DB
     let totalNutrition;
 
@@ -168,22 +164,21 @@ app.Diary = {
     }
 
     // Render category groups
-    let container = document.getElementById("diary-day");
+    let container = document.querySelector("#diary-day");
     container.innerHTML = "";
 
     for (group in app.Diary.groups)
-      app.Diary.groups[group].render(container);
+      await app.Diary.groups[group].render(container);
 
     // Render nutrition swiper card
-    let swiper = app.f7.swiper.get('#diary-nutrition .swiper-container');
-    let swiperWrapper = document.querySelector('#diary-nutrition .swiper-wrapper');
+    let swiper = app.f7.swiper.get("#diary-nutrition .swiper-container");
+    let swiperWrapper = document.querySelector("#diary-nutrition .swiper-wrapper");
     swiperWrapper.innerHTML = "";
 
     await app.Diary.renderNutritionCard(totalNutrition, new Date(app.Diary.date), swiper);
 
-    if (app.Diary.lastScrollPosition !== 0) {
-      $(".page-content").scrollTop(app.Diary.lastScrollPosition); // Restore last scroll position
-      app.Diary.lastScrollPosition = 0;
+    if (scrollPosition !== undefined) {
+      $(".page-current .page-content").scrollTop(scrollPosition); // Restore scroll position
     }
   },
 
@@ -355,12 +350,14 @@ app.Diary = {
         let entry = await app.Diary.getEntryFromDB() || app.Diary.getNewEntry();
 
         if (app.Settings.get("diary", "prompt-add-items") == true) {
-          app.Diary.promptAddItems(items, category, entry, 0);
+          let lastScrollPosition = app.Diary.lastScrollPosition;
+          app.Diary.promptAddItems(items, category, entry, 0, lastScrollPosition);
         } else {
           items.forEach((x) => {
             app.Diary.addItemToEntry(x, category, entry);
           });
           await dbHandler.put(entry, "diary");
+          app.Diary.ready = false; // Trigger fresh render
         }
 
         resolve();
@@ -371,7 +368,7 @@ app.Diary = {
     });
   },
 
-  promptAddItems: async function(items, category, entry, index) {
+  promptAddItems: async function(items, category, entry, index, lastScrollPosition) {
     let item = items[index];
 
     if (item !== undefined) {
@@ -430,7 +427,7 @@ app.Diary = {
             text: app.strings.dialogs.skip || "Skip",
             keyCodes: [27],
             onClick: async function(dialog) {
-              app.Diary.promptAddItems(items, category, entry, index + 1);
+              app.Diary.promptAddItems(items, category, entry, index + 1, lastScrollPosition);
             }
           },
           {
@@ -447,7 +444,7 @@ app.Diary = {
                 item.quantity = quantity;
 
               app.Diary.addItemToEntry(item, category, entry);
-              app.Diary.promptAddItems(items, category, entry, index + 1);
+              app.Diary.promptAddItems(items, category, entry, index + 1, lastScrollPosition);
             }
           }
           ]
@@ -456,13 +453,12 @@ app.Diary = {
       } else {
         // Item has no name (is a meal item) -> add it as is without prompt
         app.Diary.addItemToEntry(item, category, entry);
-        app.Diary.promptAddItems(items, category, entry, index + 1);
+        app.Diary.promptAddItems(items, category, entry, index + 1, lastScrollPosition);
       }
     } else {
       // No more items to process -> write entry to DB and refresh page
       await dbHandler.put(entry, "diary");
-      app.Diary.lastScrollPosition = $(".page-content").scrollTop(); // Remember scroll position
-      app.Diary.render();
+      app.Diary.render(lastScrollPosition);
     }
   },
 
@@ -483,9 +479,10 @@ app.Diary = {
         updatedItem.category = item.category;
         entry.items.splice(item.index, 1, updatedItem);
 
-        dbHandler.put(entry, "diary").onsuccess = function() {
-          resolve();
-        };
+        await dbHandler.put(entry, "diary");
+        app.Diary.ready = false; // Trigger fresh render
+
+        resolve();
       } else {
         resolve();
       }
@@ -519,8 +516,8 @@ app.Diary = {
               entry.items.splice(item.index, 1);
 
             await dbHandler.put(entry, "diary");
-            app.Diary.lastScrollPosition = $(".page-content").scrollTop(); // Remember scroll position
-            app.Diary.render();
+            let lastScrollPosition = $(".page-current .page-content").scrollTop(); // Remember scroll position
+            app.Diary.render(lastScrollPosition);
           }
         }
       ]
@@ -607,8 +604,8 @@ app.Diary = {
                 entry.items.push(item);
 
                 await dbHandler.put(entry, "diary");
-                app.Diary.lastScrollPosition = $(".page-content").scrollTop(); // Remember scroll position
-                app.Diary.render();
+                let lastScrollPosition = $(".page-current .page-content").scrollTop(); // Remember scroll position
+                app.Diary.render(lastScrollPosition);
               }
             }
           }
@@ -834,7 +831,7 @@ app.Diary = {
       date: new Date(app.Diary.calendar.getValue())
     };
 
-    app.Diary.lastScrollPosition = $(".page-content").scrollTop(); // Remember scroll position
+    app.Diary.lastScrollPosition = $(".page-current .page-content").scrollTop(); // Remember scroll position
     app.f7.views.main.router.navigate("/foods-meals-recipes/");
   },
 

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -23,7 +23,7 @@ app.Diary = {
   calendar: undefined,
   lastScrollPosition: 0,
   el: {},
-  groups: [],
+  groups: {},
 
   init: async function(context) {
 
@@ -157,9 +157,9 @@ app.Diary = {
     let entry = await this.getEntryFromDB(); // Get diary entry from DB
     let totalNutrition;
 
-    //Clear groups
-    for (let i = 0; i < app.Diary.groups.length; i++)
-      app.Diary.groups[i].reset();
+    // Clear groups
+    for (group in app.Diary.groups)
+      app.Diary.groups[group].reset();
 
     // Populate groups and get overal nutrition
     if (entry) {
@@ -171,9 +171,8 @@ app.Diary = {
     let container = document.getElementById("diary-day");
     container.innerHTML = "";
 
-    app.Diary.groups.forEach((x) => {
-      x.render(container);
-    });
+    for (group in app.Diary.groups)
+      app.Diary.groups[group].render(container);
 
     // Render nutrition swiper card
     let swiper = app.f7.swiper.get('#diary-nutrition .swiper-container');
@@ -291,16 +290,21 @@ app.Diary = {
 
   createMealGroups: function() {
     const mealNames = app.Settings.get("diary", "meal-names");
-    let groups = [];
+    let groups = {};
 
     if (mealNames !== undefined) {
       mealNames.forEach((x, i) => {
         if (x != "") {
-          let t = app.strings.diary["default-meals"][x.toLowerCase()] || x;
-          let g = app.Group.create(t, i);
-          groups.push(g);
+          let text = app.strings.diary["default-meals"][x.toLowerCase()] || x;
+          let group = app.Group.create(text, i);
+          groups[i] = group;
         }
       });
+    }
+
+    if (Object.keys(groups).length == 0) {
+      let group = app.Group.create("", 0);
+      groups[0] = group;
     }
 
     return groups;
@@ -333,7 +337,8 @@ app.Diary = {
       entry.items.forEach(async (x, i) => {
         if (x.category !== undefined) {
           x.index = i; // Index in array, not stored in DB
-          app.Diary.groups[x.category].addItem(x);
+          if (app.Diary.groups[x.category] !== undefined)
+            app.Diary.groups[x.category].addItem(x);
         }
       });
 

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -113,7 +113,7 @@ app.FoodEditor = {
       app.FoodEditor.changeServing(app.FoodEditor.item, "portion", e.target.value);
     });
     app.FoodEditor.el.portion.addEventListener("change", (e) => {
-      if (e.target.oldValue === undefined && e.target.value !== 0)
+      if (e.target.oldValue == undefined && e.target.value != 0)
         e.target.oldValue = e.target.value;
     });
 
@@ -366,6 +366,17 @@ app.FoodEditor = {
         app.FoodEditor.el.category.append(option);
       }
     });
+
+    if (app.FoodEditor.el.category.childElementCount == 0) {
+      let option = document.createElement("option");
+      option.value = 0;
+      option.setAttribute("selected", "");
+      app.FoodEditor.el.category.append(option);
+    }
+
+    if (app.FoodEditor.el.category.childElementCount == 1) {
+      app.FoodEditor.el.categoryContainer.style.display = "none";
+    }
   },
 
   populateFields: function(item) {

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -699,7 +699,7 @@ app.FoodsMealsRecipes = {
       origin = app.FoodsMealsRecipes.tab;
     } else {
       origin = "diary";
-      app.Diary.lastScrollPosition = $(".page-content").scrollTop(); // Remember scroll position
+      app.Diary.lastScrollPosition = $(".page-current .page-content").scrollTop(); // Remember scroll position
     }
 
     app.data.context = {

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -305,40 +305,47 @@ app.FoodsMealsRecipes = {
     app.data.context = {};
 
     if (origin == undefined) {
-
-      //Setup action sheet to ask user for category
+      // Setup action sheet to ask user for category
       const mealNames = app.Settings.get("diary", "meal-names");
       let options = [{
         text: app.strings.dialogs["what-meal"] || "What meal is this?",
         label: true
       }];
 
+      let category = 0;
+      let categorySelectAction = function(i) {
+        app.FoodsMealsRecipes.updateDateTimes(items);
+        app.data.context.items = items;
+        app.data.context.category = i;
+        app.f7.views.main.router.navigate("/diary/", {
+          reloadCurrent: true,
+          clearPreviousHistory: true
+        });
+      };
+
       mealNames.forEach((x, i) => {
         if (x != "") {
           let choice = {
             text: app.Utils.escapeHtml(app.strings.diary["default-meals"][x.toLowerCase()] || x),
-            onClick: function(action, e) {
-              app.FoodsMealsRecipes.updateDateTimes(items);
-              app.data.context.items = items;
-              app.data.context.category = i;
-              app.f7.views.main.router.navigate("/diary/", {
-                reloadCurrent: true,
-                clearPreviousHistory: true
-              });
-            }
+            onClick: () => { categorySelectAction(i) }
           };
+          category = i;
           options.push(choice);
         }
       });
 
-      //Create and show the action sheet
-      let ac = app.f7.actions.create({
-        buttons: options,
-        closeOnEscape: true,
-        animate: !app.Settings.get("appearance", "animations")
-      });
-
-      ac.open();
+      if (options.length > 2) {
+        // Create and show the action sheet
+        let ac = app.f7.actions.create({
+          buttons: options,
+          closeOnEscape: true,
+          animate: !app.Settings.get("appearance", "animations")
+        });
+        ac.open();
+      } else {
+        // Only one category is defined
+        categorySelectAction(category);
+      }
     } else {
       app.FoodsMealsRecipes.updateDateTimes(items);
 

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -211,9 +211,9 @@ app.Goals = {
     let goal;
 
     if (app.Goals.sharedGoal(stat) || app.measurements.includes(stat))
-      goal = goals[0];
+      goal = parseFloat(goals[0]);
     else
-      goal = goals[day];
+      goal = parseFloat(goals[day]);
 
     if (app.Goals.isPercentGoal(stat))
       goal = app.Goals.getEnergyPercentGoal(stat, goal, energyGoal);
@@ -226,9 +226,9 @@ app.Goals = {
     let averageGoal;
 
     if (app.Goals.sharedGoal(stat) || app.measurements.includes(stat)) {
-      averageGoal = goals[0];
+      averageGoal = parseFloat(goals[0]);
     } else {
-      let goalSum = goals.reduce((a, b) => Number(a) + Number(b));
+      let goalSum = goals.reduce((a, b) => parseFloat(a) + parseFloat(b));
       averageGoal = goalSum / 7;
     }
 

--- a/www/index.js
+++ b/www/index.js
@@ -391,30 +391,32 @@ if (rtl)
 
 const mainView = app.f7.views.create("#main-view", viewOptions);
 
-document.addEventListener("page:init", function(event) {
-  let page = event.detail;
+let enableDisableSwipe = function(panel) {
+  let pageName = app.f7.views.main.router.currentRoute.name || "";
+  let history = app.f7.views.main.router.history || [];
 
-  // Close panel when switching pages
-  let panel = app.f7.panel.get("#app-panel");
-  if (panel)
-    panel.close(animate);
-
-  let pageName = app.f7.views.main.router.currentRoute.name;
-
-  if (pageName !== undefined && pageName.includes("Editor"))
+  if (pageName.includes("Editor"))
+    panel.disableSwipe();
+  else if (pageName == "Chart")
+    panel.disableSwipe();
+  else if (pageName == "Foods, Meals, Recipes" && history.includes("/diary/"))
     panel.disableSwipe();
   else
     panel.enableSwipe();
+};
+
+document.addEventListener("page:init", function(event) {
+  let panel = app.f7.panel.get("#app-panel");
+  enableDisableSwipe(panel);
+
+  // Close panel when switching pages
+  if (panel)
+    panel.close(animate);
 });
 
 document.addEventListener("page:reinit", function(event) {
   let panel = app.f7.panel.get("#app-panel");
-  let pageName = app.f7.views.main.router.currentRoute.name;
-
-  if (pageName !== undefined && pageName.includes("Editor"))
-    panel.disableSwipe();
-  else
-    panel.enableSwipe();
+  enableDisableSwipe(panel);
 });
 
 app.f7.on("init", async function(event) {});
@@ -493,6 +495,12 @@ document.addEventListener("backbutton", (e) => {
     return false;
   }
 
+  let actions = document.querySelectorAll(".actions-modal");
+  if (actions.length) {
+    app.f7.actions.close(".actions-modal");
+    return false;
+  }
+
   let calendar = document.querySelectorAll(".calendar");
   if (calendar.length) {
     app.f7.calendar.close(".calendar");
@@ -505,7 +513,8 @@ document.addEventListener("backbutton", (e) => {
     return false;
   }
 
-  if (app.f7.views.main.history.length > 1) {
+  let history = new Set(app.f7.views.main.history);
+  if (history.size > 1) {
     app.f7.views.main.router.back();
   } else if (backButtonExitApp === true) {
     navigator.app.exitApp();


### PR DESCRIPTION
This closes #451.

If you only have a single diary category configured, it now hides the category dropdown in the food editor, and it no longer shows the "What meal is this?" prompt.

Also, the diary now renders correctly even if you clear all the categories or leave a gap (like `["Breakfast", "", "Dinner"]`).

While testing this on my phone, I also noticed that the implementation of the scroll position restore feature (#449) in the diary was a bit unreliable. So I made some changes to fix that. It still doesn't always work when animations are enabled, though. The page transition somehow interferes with it. Anyway, I think it's better than nothing.