### PR TITLE
Fix error handling when writing or reading backup

### DIFF
--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -334,14 +334,17 @@ app.Settings = {
           keyCodes: [13],
           onClick: async () => {
             let filename = "waistline_export.json";
-            let data = JSON.parse(await app.Utils.readFile(filename));
+            let json = await app.Utils.readFile(filename);
 
-            await dbHandler.import(data);
+            if (json !== undefined) {
+              let data = JSON.parse(json);
+              await dbHandler.import(data);
 
-            if (data.settings) {
-              let settings = app.Settings.migrateSettings(data.settings, false);
-              window.localStorage.setItem("settings", JSON.stringify(settings));
-              this.changeTheme(settings.appearance["dark-mode"], settings.appearance["theme"]);
+              if (data.settings !== undefined) {
+                let settings = app.Settings.migrateSettings(data.settings, false);
+                window.localStorage.setItem("settings", JSON.stringify(settings));
+                this.changeTheme(settings.appearance["dark-mode"], settings.appearance["theme"]);
+              }
             }
           }
         }

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -228,25 +228,34 @@ app.Utils = {
                     fileWriter.write(blob);
 
                     fileWriter.onwriteend = () => {
-                      console.log("Successul file write.");
+                      console.log("Successul file write");
                       resolve(file.fullPath);
                     };
 
                     fileWriter.onerror = (e) => {
-                      console.warn("Failed to write file", e.toString());
-                      reject();
+                      console.warn("Failed to write file", e);
+                      resolve();
                     };
                   });
 
+                }, (e) => {
+                  resolve();
                 });
+              }, (e) => {
+                resolve();
               });
+            }, (e) => {
+              resolve();
             });
+          }, (e) => {
+            resolve();
           });
         }, (e) => {
-          console.warn(e);
+          resolve();
         });
       } else {
-        console.log("Write to file doesn't work in browser");
+        console.warn("Write to file doesn't work in browser");
+        resolve();
       }
     });
   },
@@ -277,28 +286,35 @@ app.Utils = {
                     };
 
                     fileReader.onerror = (e) => {
-                      console.log("File read error", e);
-                      reject({});
+                      console.warn("Failed to read file", e);
+                      resolve();
                     };
                   });
 
                 }, (e) => {
-                  console.log("FileSystem Error", e);
-
+                  console.warn("Failed to access file", e);
                   switch (e.code) {
                     case 1:
                       alert("File not found: " + path);
                       break;
                   }
+                  resolve();
                 });
+              }, (e) => {
+                resolve();
               });
+            }, (e) => {
+              resolve();
             });
+          }, (e) => {
+            resolve();
           });
         }, (e) => {
-          console.log(e);
+          resolve();
         });
       } else {
-        console.log("Read file doesn't work in browser");
+        console.warn("Read file doesn't work in browser");
+        resolve();
       }
     });
   },


### PR DESCRIPTION
This should fix #470. It now displays an error message when the export failed instead of showing an endless spinner.