### PR TITLE
Show last applicable values when opening diary log

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -35,7 +35,7 @@ app.DiaryChart = {
     this.getComponents();
     this.bindUIActions();
 
-    let date = new Date(context.date);
+    let date = context.date;
 
     this.dbData = await app.Stats.getDataFromDb(date, 0);
 

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -91,12 +91,12 @@ app.Diary = {
             let now = new Date();
             let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
             c.setValue([today]);
-            app.Diary.date = c.getValue();
+            app.Diary.date = new Date(c.getValue());
           }
           app.Diary.updateDateDisplay();
         },
         change: function(c) {
-          app.Diary.date = c.getValue();
+          app.Diary.date = new Date(c.getValue());
           if (app.Diary.ready)
             app.Diary.render(0);
           c.close();
@@ -139,8 +139,7 @@ app.Diary = {
 
   updateDateDisplay: function() {
     let el = document.querySelector(".page[data-name='diary'] #diary-date");
-    let date = new Date(app.Diary.date);
-    let dateString = date.toLocaleDateString([], {
+    let dateString = app.Diary.date.toLocaleDateString([], {
       weekday: "short",
       month: "long",
       day: "numeric",
@@ -309,8 +308,9 @@ app.Diary = {
   getEntryFromDB: function() {
     return new Promise(async function(resolve, reject) {
       if (app.Diary.date !== undefined) {
-        let date = new Date(app.Diary.date);
-        let entry = await dbHandler.get("diary", "dateTime", new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())));
+        let date = app.Diary.date;
+        let d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        let entry = await dbHandler.get("diary", "dateTime", d);
         resolve(entry);
       }
     }).catch(err => {
@@ -319,7 +319,7 @@ app.Diary = {
   },
 
   getNewEntry: function() {
-    let date = new Date(app.Diary.date);
+    let date = app.Diary.date;
     let entry = {
       dateTime: new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())),
       items: [],
@@ -829,7 +829,7 @@ app.Diary = {
     app.data.context = {
       origin: "/diary/",
       category: category,
-      date: new Date(app.Diary.calendar.getValue())
+      date: app.Diary.date
     };
 
     app.Diary.lastScrollPosition = $(".page-current .page-content").scrollTop(); // Remember scroll position
@@ -841,7 +841,7 @@ app.Diary = {
 
     if (entry != undefined && entry.items.length > 0) {
       app.data.context = {
-        date: app.Diary.calendar.getValue()
+        date: app.Diary.date
       };
       app.f7.views.main.router.navigate("/diary/chart/");
     } else {

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -268,7 +268,8 @@ app.Goals = {
 
   getDiaryEntryFromDB: function(date) {
     return new Promise(async function(resolve, reject) {
-      let entry = await dbHandler.get("diary", "dateTime", new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())));
+      let d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+      let entry = await dbHandler.get("diary", "dateTime", d);
       resolve(entry);
     }).catch(err => {
       throw (err);


### PR DESCRIPTION
This PR changes the behaviour of the log button in the diary. In the current version, when you press the log button, the dialog gets prefilled with the last values you entered (weight, neck, hips etc.). With the changes in this PR, the dialog now shows the logged values of the selected day instead. If there are no values for the selected day yet, then it checks the previous 14 diary entries for logged values and displays the first one that it finds.