### PR TITLE
Add ability to reorder ingredients in meals and recipes

### DIFF
--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -76,7 +76,7 @@ app.Group = {
     let showTimestamps = app.Settings.get("diary", "timestamps");
     let showThumbnails = app.Utils.showThumbnails("diary");
     this.items.forEach((x) => {
-      app.FoodsMealsRecipes.renderItem(x, innerUl, false, undefined, self.removeItem, undefined, showTimestamps, showThumbnails);
+      app.FoodsMealsRecipes.renderItem(x, innerUl, false, false, undefined, self.removeItem, undefined, showTimestamps, showThumbnails);
     });
 
     let nutrition = await app.FoodsMealsRecipes.getTotalNutrition(this.items);

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -233,6 +233,12 @@ app.Foodlist = {
             keyCodes: [13],
             onClick: async () => {
               await app.FoodsMealsRecipes.removeItem(item.id, "food");
+              let index = app.Foodlist.filterList.indexOf(item);
+              if (index != -1)
+                app.Foodlist.filterList.splice(index, 1);
+              index = app.Foodlist.list.indexOf(item);
+              if (index != -1)
+                app.Foodlist.list.splice(index, 1);
               li.remove();
             }
           }

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -25,17 +25,16 @@ app.Foodlist = {
 
   init: async function(context) {
 
-    if (context) {
-      if (context.item)
-        await this.putItem(context.item);
-
+    if (context && context.item) {
+      await this.putItem(context.item);
       app.FoodsMealsRecipes.clearSearchSelection();
-      app.f7.searchbar.disable("#food-search-form");
     }
 
     this.getComponents();
     this.createSearchBar();
     this.bindUIActions();
+
+    app.Foodlist.el.scan.style.display = "block";
 
     if (!app.Foodlist.ready) {
       app.f7.infiniteScroll.create(app.Foodlist.el.infinite); //Setup infinite list
@@ -45,10 +44,10 @@ app.Foodlist = {
     app.Foodlist.list = await this.getListFromDB();
     app.Foodlist.filterList = app.Foodlist.list;
 
-    // Set scan button visibility
-    app.Foodlist.el.scan.style.display = "block";
+    await this.renderList(true);
 
-    this.renderList(true);
+    if (context)
+      app.FoodsMealsRecipes.resetSearchForm(app.Foodlist.el.searchForm, app.Foodlist.el.searchFilter, app.Foodlist.el.searchFilterIcon);
   },
 
   getComponents: function() {

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -168,7 +168,7 @@ app.Foodlist = {
 
         if (item != undefined) {
           item.type = "food";
-          app.FoodsMealsRecipes.renderItem(item, app.Foodlist.el.list, true, undefined, this.removeItem, undefined, false, showThumbnails);
+          app.FoodsMealsRecipes.renderItem(item, app.Foodlist.el.list, true, false, undefined, this.removeItem, undefined, false, showThumbnails);
         }
       }
     }

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -21,6 +21,7 @@ app.FoodEditor = {
 
   item: undefined,
   item_image_url: undefined,
+  index: undefined,
   scan: false,
   origin: undefined,
   linked: true,
@@ -38,6 +39,9 @@ app.FoodEditor = {
 
       if (context.item !== undefined)
         app.FoodEditor.item = context.item;
+
+      if (context.index !== undefined)
+        app.FoodEditor.index = context.index;
 
       if (context.item == undefined || (context.item != undefined && context.item.id == undefined))
         app.FoodEditor.linked = false; //Unlinked by default for adding new items
@@ -105,7 +109,7 @@ app.FoodEditor = {
 
     // Submit
     app.FoodEditor.el.submit.addEventListener("click", (e) => {
-      app.FoodEditor.returnItem(app.FoodEditor.item, app.FoodEditor.origin);
+      app.FoodEditor.returnItem(app.FoodEditor.item, app.FoodEditor.index, app.FoodEditor.origin);
     });
 
     // Portion
@@ -619,7 +623,7 @@ app.FoodEditor = {
     return undefined;
   },
 
-  returnItem: function(data, origin) {
+  returnItem: function(data, index, origin) {
     let item = app.FoodEditor.gatherFormData(data, origin);
 
     if (item !== undefined) {
@@ -630,7 +634,8 @@ app.FoodEditor = {
       item.archived = false;
 
       app.data.context = {
-        item: item
+        item: item,
+        index: index
       };
 
       app.f7.views.main.router.back();

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -386,7 +386,7 @@ app.FoodsMealsRecipes = {
     return 0;
   },
 
-  renderItem: async function(data, el, checkbox, clickCallback, tapholdCallback, checkboxCallback, timestamp, thumbnail) {
+  renderItem: async function(data, el, checkbox, sortable, clickCallback, tapholdCallback, checkboxCallback, timestamp, thumbnail) {
 
     if (data !== undefined) {
 
@@ -405,6 +405,7 @@ app.FoodsMealsRecipes = {
       if (item !== undefined) {
 
         let li = document.createElement("li");
+        li.data = JSON.stringify(item);
         el.appendChild(li);
 
         let label = document.createElement("label");
@@ -430,6 +431,12 @@ app.FoodsMealsRecipes = {
           let icon = document.createElement("i");
           icon.className = "icon icon-checkbox";
           label.appendChild(icon);
+        }
+        //Sortable handler
+        else if (sortable) {
+          let sortHandler = document.createElement("div");
+          sortHandler.className = "sortable-handler";
+          li.appendChild(sortHandler);
         }
 
         //Thumbnail

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -449,7 +449,7 @@ app.FoodsMealsRecipes = {
           inner.addEventListener("click", function(e) {
             e.preventDefault();
             if (clickCallback !== undefined)
-              clickCallback(item);
+              clickCallback(item, li);
             else
               app.FoodsMealsRecipes.gotoEditor(item);
           });
@@ -687,7 +687,7 @@ app.FoodsMealsRecipes = {
       container.style.display = "none";
   },
 
-  gotoEditor: function(item) {
+  gotoEditor: function(item, index) {
     let origin;
     if (app.FoodsMealsRecipes.tab !== undefined) {
       origin = app.FoodsMealsRecipes.tab;
@@ -698,6 +698,7 @@ app.FoodsMealsRecipes = {
 
     app.data.context = {
       item: item,
+      index: index,
       origin: origin
     };
 

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -620,6 +620,12 @@ app.FoodsMealsRecipes = {
     app.FoodsMealsRecipes.updateSelectionCount();
   },
 
+  resetSearchForm: function(searchForm, searchFilter, searchFilterIcon) {
+    $(".page-content").scrollTop(0);
+    app.f7.searchbar.disable(searchForm);
+    app.FoodsMealsRecipes.clearSelectedCategories(searchFilter, searchFilterIcon);
+  },
+
   getSelection: function() {
     return app.FoodsMealsRecipes.selection;
   },
@@ -795,14 +801,13 @@ document.addEventListener("page:reinit", function(e) {
     let context = app.data.context;
     app.data.context = undefined;
 
-    if (context !== undefined && context.item !== undefined) {
-      if (app.FoodsMealsRecipes.tab == "foodlist") {
+    if (context !== undefined) {
+      if (context.item !== undefined && app.FoodsMealsRecipes.tab == "foodlist")
         app.Foodlist.init(context);
-      }
-    } else if (app.FoodsMealsRecipes.tab == "meals") {
-      app.Meals.init();
-    } else if (app.FoodsMealsRecipes.tab == "recipes") {
-      app.Recipes.init();
+      else if (context.meal !== undefined && app.FoodsMealsRecipes.tab == "meals")
+        app.Meals.init(context);
+      else if (context.recipe !== undefined && app.FoodsMealsRecipes.tab == "recipes")
+        app.Recipes.init(context);
     }
   }
 });

--- a/www/activities/goals/js/goal-editor.js
+++ b/www/activities/goals/js/goal-editor.js
@@ -75,7 +75,7 @@ app.GoalEditor = {
     const inputs = Array.from(document.querySelectorAll("input:not(.manual-bind)"));
 
     inputs.forEach((x, i) => {
-      if (!x.hasChangeEvent) {
+      if (x.hasAttribute("field") && x.hasAttribute("name") && !x.hasChangeEvent) {
         x.addEventListener("change", (e) => {
           app.Settings.saveInputs(inputs);
         });

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -99,6 +99,19 @@ app.MealEditor = {
       });
       app.MealEditor.el.nutritionButton.hasClickEvent = true;
     }
+
+    // Item list sort
+    if (!app.MealEditor.el.foodlist.hasSortableEvent) {
+      app.MealEditor.el.foodlist.addEventListener("sortable:sort", (li) => {
+        let items = app.MealEditor.el.foodlist.getElementsByTagName("li");
+        app.MealEditor.meal.items = [];
+        for (let i = 0; i < items.length; i++) {
+          let item = app.FoodsMealsRecipes.flattenItem(JSON.parse(items[i].data));
+          app.MealEditor.meal.items.push(item);
+        }
+      });
+      app.MealEditor.el.foodlist.hasSortableEvent = true;
+    }
   },
 
   setRequiredFieldErrorMessage: function() {
@@ -245,8 +258,9 @@ app.MealEditor = {
       let showThumbnails = app.Utils.showThumbnails("foodlist");
 
       app.MealEditor.meal.items.forEach(async (x, i) => {
-        app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, app.MealEditor.mealItemClickHandler, app.MealEditor.removeItem, undefined, false, showThumbnails);
+        app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, true, app.MealEditor.mealItemClickHandler, app.MealEditor.removeItem, undefined, false, showThumbnails);
       });
+      app.f7.sortable.enable(app.MealEditor.el.foodlist);
 
       resolve();
     });

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -193,6 +193,10 @@ app.MealEditor = {
       if (categories !== undefined)
         data.categories = categories;
 
+      app.data.context = {
+        meal: data
+      };
+
       dbHandler.put(data, "meals").onsuccess = () => {
         app.f7.views.main.router.back();
       };

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -27,7 +27,7 @@ app.MealEditor = {
 
     if (context) {
 
-      // From meal list or food list
+      // From meal list
       if (context.meal) {
         app.MealEditor.meal = context.meal;
         app.MealEditor.populateInputs(context.meal);
@@ -35,12 +35,13 @@ app.MealEditor = {
 
       app.FoodsMealsRecipes.populateCategoriesField(app.MealEditor.el.categories, app.MealEditor.meal, true, true);
 
+      // From food list
       if (context.items)
         app.MealEditor.addItems(context.items);
 
-      // Returned from meal editor
-      if (context.item)
-        app.MealEditor.replaceListItem(context.item);
+      // Returned from food editor
+      if (context.item && context.index != undefined)
+        app.MealEditor.replaceListItem(context.item, context.index);
 
       app.MealEditor.renderNutrition();
       await app.MealEditor.renderItems();
@@ -148,9 +149,10 @@ app.MealEditor = {
           text: app.strings.dialogs.delete || "Delete",
           keyCodes: [13],
           onClick: () => {
-            app.MealEditor.meal.items.splice(item.index, 1);
-            app.MealEditor.renderItems();
+            let index = $(li).index();
+            app.MealEditor.meal.items.splice(index, 1);
             app.MealEditor.renderNutrition();
+            li.remove();
           }
         }
       ]
@@ -178,23 +180,20 @@ app.MealEditor = {
       if (categories !== undefined)
         data.categories = categories;
 
-      // Array index should not be saved with items
-      if (data.items !== undefined) {
-        data.items.forEach((x) => {
-          if (x.index !== undefined)
-            delete x.index;
-        });
-      }
-
       dbHandler.put(data, "meals").onsuccess = () => {
         app.f7.views.main.router.back();
       };
     }
   },
 
-  replaceListItem: function(item) {
+  mealItemClickHandler: function(item, li) {
+    let index = $(li).index();
+    app.FoodsMealsRecipes.gotoEditor(item, index);
+  },
+
+  replaceListItem: function(item, index) {
     let updatedItem = app.FoodsMealsRecipes.flattenItem(item);
-    app.MealEditor.meal.items.splice(item.index, 1, updatedItem);
+    app.MealEditor.meal.items.splice(index, 1, updatedItem);
   },
 
   renderNutrition: async function() {
@@ -246,8 +245,7 @@ app.MealEditor = {
       let showThumbnails = app.Utils.showThumbnails("foodlist");
 
       app.MealEditor.meal.items.forEach(async (x, i) => {
-        x.index = i;
-        app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, undefined, app.MealEditor.removeItem, undefined, false, showThumbnails);
+        app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, app.MealEditor.mealItemClickHandler, app.MealEditor.removeItem, undefined, false, showThumbnails);
       });
 
       resolve();

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -264,7 +264,7 @@ app.MealEditor = {
       app.MealEditor.meal.items.forEach(async (x, i) => {
         app.FoodsMealsRecipes.renderItem(x, app.MealEditor.el.foodlist, false, true, app.MealEditor.mealItemClickHandler, app.MealEditor.removeItem, undefined, false, showThumbnails);
       });
-      app.f7.sortable.enable(app.MealEditor.el.foodlist);
+      app.f7.sortable.disable(app.MealEditor.el.foodlist);
 
       resolve();
     });

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -19,11 +19,14 @@
 
 app.Meals = {
 
-  list: [], //Main list of foods
+  list: [], //Main list of meals
   filterList: [], //Copy of the list for filtering
   el: {}, //UI elements
 
   init: async function(context) {
+
+    if (context)
+      app.FoodsMealsRecipes.clearSearchSelection();
 
     app.Meals.getComponents();
     app.Meals.createSearchBar();
@@ -39,7 +42,10 @@ app.Meals = {
     app.Meals.list = await app.Meals.getListFromDB();
     app.Meals.filterList = app.Meals.list;
 
-    app.Meals.renderList(true);
+    await app.Meals.renderList(true);
+
+    if (context)
+      app.FoodsMealsRecipes.resetSearchForm(app.Meals.el.searchForm, app.Meals.el.searchFilter, app.Meals.el.searchFilterIcon);
   },
 
   getComponents: function() {

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -93,7 +93,7 @@ app.Meals = {
         let item = app.Meals.list[i];
 
         item.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(item.items);
-        app.FoodsMealsRecipes.renderItem(item, app.Meals.el.list, true, app.Meals.gotoEditor, app.Meals.deleteMeal);
+        app.FoodsMealsRecipes.renderItem(item, app.Meals.el.list, true, false, app.Meals.gotoEditor, app.Meals.deleteMeal);
       }
     }
   },

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -25,16 +25,11 @@ app.Meals = {
 
   init: async function(context) {
 
-    if (context !== undefined) {
-      if (context.meal)
-        app.Meals.meal = context.meal;
-    } else {
-      app.Meals.meal = undefined;
-    }
-
     app.Meals.getComponents();
     app.Meals.createSearchBar();
     app.Meals.bindUIActions();
+
+    app.Meals.el.scan.style.display = "none";
 
     if (!app.Meals.ready) {
       app.f7.infiniteScroll.create(app.Meals.el.infinite); //Setup infinite list
@@ -50,7 +45,6 @@ app.Meals = {
   getComponents: function() {
     app.Meals.el.submit = document.querySelector(".page[data-name='foods-meals-recipes'] #submit");
     app.Meals.el.scan = document.querySelector(".page[data-name='foods-meals-recipes'] #scan");
-    app.Meals.el.scan.style.display = "none";
     app.Meals.el.title = document.querySelector(".page[data-name='foods-meals-recipes'] #title");
     app.Meals.el.search = document.querySelector("#meals-tab #meal-search");
     app.Meals.el.searchForm = document.querySelector("#meals-tab #meal-search-form");
@@ -67,7 +61,7 @@ app.Meals = {
     // Infinite list - render more items
     if (!app.Meals.el.infinite.hasInfiniteEvent) {
       app.Meals.el.infinite.addEventListener("infinite", (e) => {
-        this.renderList();
+        app.Meals.renderList();
       });
       app.Meals.el.infinite.hasInfiniteEvent = true;
     }
@@ -97,9 +91,6 @@ app.Meals = {
         if (i >= app.Meals.list.length) break; //Exit after all items in list
 
         let item = app.Meals.list[i];
-
-        // Don't show item that is being edited, otherwise endless loop will ensue
-        if (app.Meals.meal !== undefined && app.Meals.meal.id == item.id) continue;
 
         item.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(item.items);
         app.FoodsMealsRecipes.renderItem(item, app.Meals.el.list, true, app.Meals.gotoEditor, app.Meals.deleteMeal);
@@ -192,6 +183,12 @@ app.Meals = {
             let request = dbHandler.deleteItem(item.id, "meals");
 
             request.onsuccess = function(e) {
+              let index = app.Meals.filterList.indexOf(item);
+              if (index != -1)
+                app.Meals.filterList.splice(index, 1);
+              index = app.Meals.list.indexOf(item);
+              if (index != -1)
+                app.Meals.list.splice(index, 1);
               li.remove();
             };
           }

--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -76,7 +76,7 @@
             </div>
           </a>
           <div class="accordion-item-content">
-            <div class="list media-list">
+            <div class="list media-list sortable">
               <ul id="meal-food-list">
               </ul>
             </div>

--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -29,6 +29,7 @@
       </div>
       <div class="title" id="title" data-localize="meal-editor.title">Edit Meal</div>
       <div class="right">
+        <a href="#" class="link sortable-toggle" data-sortable="#meal-food-list"><i class="icon material-icons">swap_vert</i></a>
         <a href="#" id="submit" class="link icon-only"><i class="icon material-icons">done</i></a>
       </div>
     </div>

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -99,6 +99,19 @@ app.RecipeEditor = {
       });
       app.RecipeEditor.el.nutritionButton.hasClickEvent = true;
     }
+
+    // Item list sort
+    if (!app.RecipeEditor.el.foodlist.hasSortableEvent) {
+      app.RecipeEditor.el.foodlist.addEventListener("sortable:sort", (li) => {
+        let items = app.RecipeEditor.el.foodlist.getElementsByTagName("li");
+        app.RecipeEditor.recipe.items = [];
+        for (let i = 0; i < items.length; i++) {
+          let item = app.FoodsMealsRecipes.flattenItem(JSON.parse(items[i].data));
+          app.RecipeEditor.recipe.items.push(item);
+        }
+      });
+      app.RecipeEditor.el.foodlist.hasSortableEvent = true;
+    }
   },
 
   setRequiredFieldErrorMessage: function() {
@@ -248,8 +261,9 @@ app.RecipeEditor = {
       let showThumbnails = app.Utils.showThumbnails("foodlist");
 
       app.RecipeEditor.recipe.items.forEach(async (x, i) => {
-        app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, app.RecipeEditor.recipeItemClickHandler, app.RecipeEditor.removeItem, undefined, false, showThumbnails);
+        app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, true, app.RecipeEditor.recipeItemClickHandler, app.RecipeEditor.removeItem, undefined, false, showThumbnails);
       });
+      app.f7.sortable.enable(app.RecipeEditor.el.foodlist);
 
       resolve();
     });

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -196,6 +196,10 @@ app.RecipeEditor = {
       if (app.RecipeEditor.recipe.items !== undefined)
         data.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(app.RecipeEditor.recipe.items);
 
+      app.data.context = {
+        recipe: data
+      };
+
       dbHandler.put(data, "recipes").onsuccess = () => {
         app.f7.views.main.router.back();
       };

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -267,7 +267,7 @@ app.RecipeEditor = {
       app.RecipeEditor.recipe.items.forEach(async (x, i) => {
         app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, true, app.RecipeEditor.recipeItemClickHandler, app.RecipeEditor.removeItem, undefined, false, showThumbnails);
       });
-      app.f7.sortable.enable(app.RecipeEditor.el.foodlist);
+      app.f7.sortable.disable(app.RecipeEditor.el.foodlist);
 
       resolve();
     });

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -39,9 +39,9 @@ app.RecipeEditor = {
       if (context.items)
         app.RecipeEditor.addItems(context.items);
 
-      // From recipe editor
-      if (context.item)
-        app.RecipeEditor.replaceListItem(context.item);
+      // Returned from food editor
+      if (context.item && context.index != undefined)
+        app.RecipeEditor.replaceListItem(context.item, context.index);
 
       app.RecipeEditor.renderNutrition();
       await app.RecipeEditor.renderItems();
@@ -149,9 +149,10 @@ app.RecipeEditor = {
           text: app.strings.dialogs.delete || "Delete",
           keyCodes: [13],
           onClick: () => {
-            app.RecipeEditor.recipe.items.splice(item.index, 1);
-            app.RecipeEditor.renderItems();
+            let index = $(li).index();
+            app.RecipeEditor.recipe.items.splice(index, 1);
             app.RecipeEditor.renderNutrition();
+            li.remove();
           }
         }
       ]
@@ -179,14 +180,6 @@ app.RecipeEditor = {
       if (categories !== undefined)
         data.categories = categories;
 
-      // Array index should not be saved with items
-      if (data.items !== undefined) {
-        data.items.forEach((x) => {
-          if (x.index !== undefined)
-            delete x.index;
-        });
-      }
-
       if (app.RecipeEditor.recipe.items !== undefined)
         data.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(app.RecipeEditor.recipe.items);
 
@@ -196,9 +189,14 @@ app.RecipeEditor = {
     }
   },
 
-  replaceListItem: function(item) {
+  recipeItemClickHandler: function(item, li) {
+    let index = $(li).index();
+    app.FoodsMealsRecipes.gotoEditor(item, index);
+  },
+
+  replaceListItem: function(item, index) {
     let updatedItem = app.FoodsMealsRecipes.flattenItem(item);
-    app.RecipeEditor.recipe.items.splice(item.index, 1, updatedItem);
+    app.RecipeEditor.recipe.items.splice(index, 1, updatedItem);
   },
 
   renderNutrition: async function() {
@@ -250,8 +248,7 @@ app.RecipeEditor = {
       let showThumbnails = app.Utils.showThumbnails("foodlist");
 
       app.RecipeEditor.recipe.items.forEach(async (x, i) => {
-        x.index = i;
-        app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, undefined, app.RecipeEditor.removeItem, undefined, false, showThumbnails);
+        app.FoodsMealsRecipes.renderItem(x, app.RecipeEditor.el.foodlist, false, app.RecipeEditor.recipeItemClickHandler, app.RecipeEditor.removeItem, undefined, false, showThumbnails);
       });
 
       resolve();

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -25,16 +25,11 @@ app.Recipes = {
 
   init: async function(context) {
 
-    if (context !== undefined) {
-      if (context.recipe)
-        app.Recipes.recipe = context.recipe;
-    } else {
-      app.Recipes.recipe = undefined;
-    }
-
     app.Recipes.getComponents();
     app.Recipes.createSearchBar();
     app.Recipes.bindUIActions();
+
+    app.Recipes.el.scan.style.display = "none";
 
     if (!app.Recipes.ready) {
       app.f7.infiniteScroll.create(app.Recipes.el.infinite); //Setup infinite list
@@ -50,7 +45,6 @@ app.Recipes = {
   getComponents: function() {
     app.Recipes.el.submit = document.querySelector(".page[data-name='foods-meals-recipes'] #submit");
     app.Recipes.el.scan = document.querySelector(".page[data-name='foods-meals-recipes'] #scan");
-    app.Recipes.el.scan.style.display = "none";
     app.Recipes.el.title = document.querySelector(".page[data-name='foods-meals-recipes'] #title");
     app.Recipes.el.search = document.querySelector("#recipes-tab #recipe-search");
     app.Recipes.el.searchForm = document.querySelector("#recipes-tab #recipe-search-form");
@@ -98,9 +92,6 @@ app.Recipes = {
 
         let item = app.Recipes.list[i];
 
-        // Don't show item that is being edited, otherwise endless loop will ensue
-        if (app.Recipes.recipe !== undefined && app.Recipes.recipe.id == item.id) continue;
-
         if (item.archived !== true) {
           item.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(item.items);
           app.FoodsMealsRecipes.renderItem(item, app.Recipes.el.list, true, app.Recipes.gotoEditor, app.Recipes.removeItem);
@@ -139,6 +130,12 @@ app.Recipes = {
           keyCodes: [13],
           onClick: async () => {
             await app.FoodsMealsRecipes.removeItem(item.id, "recipe");
+            let index = app.Recipes.filterList.indexOf(item);
+            if (index != -1)
+              app.Recipes.filterList.splice(index, 1);
+            index = app.Recipes.list.indexOf(item);
+            if (index != -1)
+              app.Recipes.list.splice(index, 1);
             li.remove();
           }
         }

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -94,7 +94,7 @@ app.Recipes = {
 
         if (item.archived !== true) {
           item.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(item.items);
-          app.FoodsMealsRecipes.renderItem(item, app.Recipes.el.list, true, app.Recipes.gotoEditor, app.Recipes.removeItem);
+          app.FoodsMealsRecipes.renderItem(item, app.Recipes.el.list, true, false, app.Recipes.gotoEditor, app.Recipes.removeItem);
         }
       }
     }

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -19,11 +19,14 @@
 
 app.Recipes = {
 
-  list: [], //Main list of foods
+  list: [], //Main list of recipes
   filterList: [], //Copy of the list for filtering
   el: {}, //UI elements
 
   init: async function(context) {
+
+    if (context)
+      app.FoodsMealsRecipes.clearSearchSelection();
 
     app.Recipes.getComponents();
     app.Recipes.createSearchBar();
@@ -39,7 +42,10 @@ app.Recipes = {
     app.Recipes.list = await app.Recipes.getListFromDB();
     app.Recipes.filterList = app.Recipes.list;
 
-    app.Recipes.renderList(true);
+    await app.Recipes.renderList(true);
+
+    if (context)
+      app.FoodsMealsRecipes.resetSearchForm(app.Recipes.el.searchForm, app.Recipes.el.searchFilter, app.Recipes.el.searchFilterIcon);
   },
 
   getComponents: function() {

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -29,6 +29,7 @@
       </div>
       <div class="title" id="title" data-localize="recipe-editor.title">Edit Recipe</div>
       <div class="right">
+        <a href="#" class="link sortable-toggle" data-sortable="#recipe-food-list"><i class="icon material-icons">swap_vert</i></a>
         <a href="#" id="submit" class="link icon-only"><i class="icon material-icons">done</i></a>
       </div>
     </div>

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -103,7 +103,7 @@
             </div>
           </a>
           <div class="accordion-item-content">
-            <div class="list media-list">
+            <div class="list media-list sortable">
               <ul id="recipe-food-list">
               </ul>
             </div>

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -196,11 +196,11 @@ app.Settings = {
     // Nutriment list 
     let nutrimentList = document.getElementById("nutriment-list");
     if (nutrimentList != undefined) {
-      app.f7.on("sortableSort", (e, data) => {
-        let li = nutrimentList.getElementsByTagName("li");
+      nutrimentList.addEventListener("sortable:sort", (li) => {
+        let items = nutrimentList.getElementsByTagName("li");
         let newOrder = [];
-        for (let i = 0; i < li.length - 1; i++) {
-          newOrder.push(li[i].id);
+        for (let i = 0; i < items.length - 1; i++) {
+          newOrder.push(items[i].id);
         }
         app.Settings.put("nutriments", "order", newOrder);
       });
@@ -209,11 +209,11 @@ app.Settings = {
     // Food labels/categories list
     let categoriesList = document.getElementById("food-categories-list");
     if (categoriesList != undefined) {
-      app.f7.on("sortableSort", (e, data) => {
-        let li = categoriesList.getElementsByTagName("li");
+      categoriesList.addEventListener("sortable:sort", (li) => {
+        let items = categoriesList.getElementsByTagName("li");
         let newOrder = [];
-        for (let i = 0; i < li.length - 1; i++) {
-          newOrder.push(li[i].id);
+        for (let i = 0; i < items.length - 1; i++) {
+          newOrder.push(items[i].id);
         }
         app.Settings.put("foodlist", "labels", newOrder);
       });

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -113,10 +113,13 @@ app.Settings = {
     const inputs = Array.from(document.querySelectorAll("input:not(.manual-bind), select"));
 
     inputs.forEach((x, i) => {
-      x.addEventListener("change", (e) => {
-        app.Settings.saveInputs(inputs);
-        app.Settings.resetModuleReadyStates(); //Reset modules for changes to take effect
-      });
+      if (x.hasAttribute("field") && x.hasAttribute("name") && !x.hasChangeEvent) {
+        x.addEventListener("change", (e) => {
+          app.Settings.saveInputs(inputs);
+          app.Settings.resetModuleReadyStates(); //Reset modules for changes to take effect
+        });
+        x.hasChangeEvent = true;
+      }
     });
 
     // Open food facts credentials login button

--- a/www/activities/settings/views/import-export.html
+++ b/www/activities/settings/views/import-export.html
@@ -48,11 +48,11 @@
         </li>
 
         <li>
-          <p><a href="#" class="button button-large manual-bind" id="export-db" data-localize="settings.import-export.backup">Backup Database</a></p>
+          <p><a href="#" class="button button-large" id="export-db" data-localize="settings.import-export.backup">Backup Database</a></p>
         </li>
 
         <li>
-          <a href="#" class="button button-large manual-bind" id="import-db" data-localize="settings.import-export.import">Import From Backup</a>
+          <a href="#" class="button button-large" id="import-db" data-localize="settings.import-export.import">Import From Backup</a>
         </li>
 
       </ul>

--- a/www/index.js
+++ b/www/index.js
@@ -510,6 +510,7 @@ document.addEventListener("backbutton", (e) => {
 
   let searchField = document.querySelector(".page-current input[type='search']");
   if (searchField && searchField.value) {
+    $(".page-current .page-content").scrollTop(0);
     app.f7.searchbar.disable(".searchbar");
     return false;
   }


### PR DESCRIPTION
This adds a toggle button in the meal and recipe editors to show/hide sort handlers which can be used to reorder the ingredients. This is a feature I wanted to have for a while.
Closes #212.

![localhost_](https://user-images.githubusercontent.com/19289477/154665494-f2bbc55c-dad7-4c25-9527-2ec4b0d9b819.png)

#

![localhost_ (1)](https://user-images.githubusercontent.com/19289477/154665498-39da3984-3f52-45d7-9a87-cfb6f0d6d469.png)

#

![localhost_ (2)](https://user-images.githubusercontent.com/19289477/154665499-16f5d07b-4032-473a-9b6e-82b0cc733c4c.png)
