### PR TITLE
Fix goal editor input event handlers

### DIFF
--- a/www/activities/goals/js/goal-editor.js
+++ b/www/activities/goals/js/goal-editor.js
@@ -24,7 +24,6 @@ app.GoalEditor = {
 
   init: function(context) {
     this.getComponents();
-    this.bindUIActions();
 
     if (context.stat !== undefined) {
       const inputs = Array.from(document.querySelectorAll("input"));
@@ -35,6 +34,7 @@ app.GoalEditor = {
       this.stat = context.stat;
     }
 
+    this.bindUIActions();
     this.hideShowComponents();
   },
 


### PR DESCRIPTION
This fixes #496. The event handlers must be added _after_ the input names have been set.