### PR TITLE
Include current weekday in auto-backup filename

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -451,7 +451,8 @@ document.addEventListener('deviceready', async function() {
       data.settings = settings;
       let json = JSON.stringify(data);
 
-      let filename = "waistline_auto_backup.json";
+      let weekday = (new Date()).toLocaleDateString("en", {weekday: "long"}).toLowerCase();
+      let filename = "waistline_backup_" + weekday + ".json";
       let path = await app.Utils.writeFile(json, filename);
     }
   }, 2000);


### PR DESCRIPTION
This closes #350 and should address the concerns raised in https://github.com/davidhealey/waistline/issues/501#issuecomment-1057120468.

The auto-backup now uses filenames like `waistline_backup_wednesday.json`, `waistline_backup_thursday.json` and so on.