### PR TITLE
Improve diary scroll position restore feature

### DIFF
--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -97,6 +97,7 @@ app.Group = {
     //Add button 
     let left = document.createElement("div");
     left.className = "add-button";
+    left.id = "add-button-" + id;
     row.appendChild(left);
 
     let a = document.createElement("a");

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -54,6 +54,17 @@ app.Utils = {
     }
   },
 
+  getElementOffsetTop: function(element) {
+    var offsetTop = 0;
+    if (element) {
+      do {
+        if (!isNaN(element.offsetTop))
+          offsetTop += element.offsetTop;
+      } while (element = element.offsetParent);
+    }
+    return offsetTop;
+  },
+
   isInternetConnected: function() {
     if (navigator.connection.type == "none") {
       let msg = app.strings.dialogs["no-internet"] || "No Internet Connection";


### PR DESCRIPTION
This PR improves the scroll position restore feature in the diary. It now always scrolls the `+` button into view after adding items as suggested in https://github.com/davidhealey/waistline/pull/449#issuecomment-1044853228. Also, it now works even when animations are enabled (it didn't before).