### PR TITLE
Change backup location to Documents directory

### DIFF
--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -49,6 +49,8 @@ html[dir="rtl"] img.food-thumbnail {margin: 0.2em 0 0.2em 1em;}
 .list .item-title-row .item-after {align-self: flex-start;}
 .list .item-subtitle {font-style: italic;}
 
+.notification-text {overflow-wrap: break-word;}
+
 /* Custom color themes */
 .color-theme-pink {
   --f7-theme-color: #f6b0ba;

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -212,20 +212,32 @@ app.Utils = {
     return Object.keys(app.nutrimentUnits).find(key => app.nutrimentUnits[key] === energyUnit);
   },
 
+  getBackupDirectoryName: function() {
+    let dirname = window.localStorage.getItem("backup-dir");
+
+    if (dirname == undefined) {
+      dirname = Math.floor(Date.now() / 1000).toString();
+      window.localStorage.setItem("backup-dir", dirname);
+    }
+
+    return dirname;
+  },
+
   writeFile: function(data, filename) {
     return new Promise(function(resolve, reject) {
       if (app.mode !== "development" && device.platform !== "browser") {
 
         let base = cordova.file.externalRootDirectory;
-        let path = base + "Android/media/com.waist.line/" + filename;
+        let dirname = app.Utils.getBackupDirectoryName();
+        let path = base + `Documents/Waistline/${dirname}/${filename}`;
 
         console.log("Writing data to file: " + path);
 
         window.resolveLocalFileSystemURL(base, (baseDir) => {
-          baseDir.getDirectory("Android", { create: true }, function (androidDir) {
-            androidDir.getDirectory("media", { create: true }, function (mediaDir) {
-              mediaDir.getDirectory("com.waist.line", { create: true }, function (appDir) {
-                appDir.getFile(filename, { create: true }, (file) => {
+          baseDir.getDirectory("Documents", { create: true }, function (documentsDir) {
+            documentsDir.getDirectory("Waistline", { create: true }, function (waistlineDir) {
+              waistlineDir.getDirectory(dirname, { create: true }, function (backupDir) {
+                backupDir.getFile(filename, { create: true }, (file) => {
 
                   // Write to the file, overwriting existing content
                   file.createWriter((fileWriter) => {
@@ -273,15 +285,16 @@ app.Utils = {
       if (app.mode !== "development" && device.platform !== "browser") {
 
         let base = cordova.file.externalRootDirectory;
-        let path = base + "Android/media/com.waist.line/" + filename;
+        let dirname = app.Utils.getBackupDirectoryName();
+        let path = base + `Documents/Waistline/${dirname}/${filename}`;
 
         console.log("Reading file: " + path);
 
         window.resolveLocalFileSystemURL(base, (baseDir) => {
-          baseDir.getDirectory("Android", { create: true }, function (androidDir) {
-            androidDir.getDirectory("media", { create: true }, function (mediaDir) {
-              mediaDir.getDirectory("com.waist.line", { create: true }, function (appDir) {
-                appDir.getFile(filename, {}, (file) => {
+          baseDir.getDirectory("Documents", { create: true }, function (documentsDir) {
+            documentsDir.getDirectory("Waistline", { create: true }, function (waistlineDir) {
+              waistlineDir.getDirectory(dirname, { create: true }, function (backupDir) {
+                backupDir.getFile(filename, {}, (file) => {
 
                   file.file((file) => {
                     let fileReader = new FileReader();


### PR DESCRIPTION
This is a proposal to solve #410.

Here's what I did:

I changed the backup location to a directory within the Documents folder: `/storage/emulated/0/Documents/Waistline`. Specifically, the first time you use the backup/export feature, Waistline creates a unique backup directory within this folder, e.g. `/storage/emulated/0/Documents/Waistline/1647011571`. All backups and exports are put in this directory (the directory name is just the unix timestamp from the first time you used the backup/export feature, and it is saved in localstorage).

If you ever uninstall Waistline, the backup directory and files are not deleted! 🙌 

If you then reinstall Waistline, the new installation will be unable to overwrite the files created by the previous installation. But since the new installation also creates a new unique backup directory, e.g. `/storage/emulated/0/Documents/Waistline/1647011830`, this is not an issue.

What do you think of this solution?