### PR TITLE
Add ability to set goals with effective from date

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -237,7 +237,7 @@ app.Diary = {
     let goals = await app.Goals.getGoals(nutrimentsToShow, date);
 
     nutrimentsToShow.forEach((x) => {
-      let goal = goals[x];
+      let nutrimentGoal = goals[x];
 
       // Show n nutriments at a time
       if (count % columnsToShow == 0) {
@@ -265,7 +265,7 @@ app.Diary = {
       title.appendChild(t);
       rows[0].appendChild(title);
 
-      // Values and goal text
+      // Value
       let values = document.createElement("div");
       values.className = "col keep-ltr";
       values.id = x + "-value";
@@ -282,12 +282,12 @@ app.Diary = {
       }
       t.nodeValue = app.Utils.tidyNumber(value);
 
-      // Set value text colour
-      if (goal !== undefined && goal !== "" && !isNaN(goal)) {
+      // Value colour and goal
+      let goal = nutrimentGoal.goal;
+      let isMin = nutrimentGoal.isMin;
 
-        let isMin = app.Goals.isMinimumGoal(x);
-
-        if ((!isMin && value > goal) || (isMin == true && value < goal))
+      if (goal !== undefined && !isNaN(goal)) {
+        if ((isMin !== true && value > goal) || (isMin === true && value < goal))
           span.style.color = "red";
         else
           span.style.color = "green";

--- a/www/activities/goals/js/goal-editor.js
+++ b/www/activities/goals/js/goal-editor.js
@@ -263,7 +263,7 @@ app.GoalEditor = {
     let now = new Date();
     let today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
     let newGoal = {
-      effectiveFrom: today
+      "effective-from": today
     };
 
     // Add to goal list in settings
@@ -327,8 +327,8 @@ app.GoalEditor = {
       option.setAttribute("selected", "");
 
     let text = goalString + " " + (i + 1);
-    if (goal.effectiveFrom !== undefined) {
-      let date = new Date(goal.effectiveFrom);
+    if (goal["effective-from"] !== undefined) {
+      let date = new Date(goal["effective-from"]);
       let dateString = date.toLocaleDateString([], {
         year: "numeric",
         month: "2-digit",

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -301,13 +301,13 @@ app.Goals = {
           if (date == undefined)
             return goal; // Immediately return last (= most recent) goal from the list
 
-          if (goal.effectiveFrom != undefined) {
-            let effectiveFromDate = new Date(goal.effectiveFrom);
+          if (goal["effective-from"] != undefined) {
+            let effectiveFromDate = new Date(goal["effective-from"]);
             let requestedDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
             if (effectiveFromDate <= requestedDate)
               return goal; // Return goal if it became effective before the requested date
           } else {
-            return goal; // Goal has no effectiveFrom date so just return it
+            return goal; // Goal has no effective-from date so just return it
           }
         }
       }

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -27,7 +27,7 @@ app.Goals = {
   },
 
   getComponents: function() {
-    app.Goals.el.list = document.getElementById("goal-list");
+    app.Goals.el.list = document.querySelector(".page[data-name='goals'] #goal-list");
   },
 
   populateGoalList: function() {
@@ -44,7 +44,7 @@ app.Goals = {
 
       if ((x == "calories" || x == "kilojoules") && units[x] != energyUnit) continue;
 
-      let unit = app.Goals.getGoalUnit(x);
+      let unit = app.Goals.getGoalUnit(x, true);
       let unitSymbol = app.strings["unit-symbols"][unit] || unit;
 
       let li = document.createElement("li");
@@ -73,7 +73,7 @@ app.Goals = {
     app.f7.views.main.router.navigate("./goal-editor/");
   },
 
-  getGoalUnit(stat, checkPercentGoal=true) {
+  getGoalUnit(stat, checkPercentGoal) {
     const preferredUnits = app.Settings.getField("units") || {};
     const units = app.Utils.concatObjects(app.Nutriments.getNutrimentUnits(), preferredUnits);
 
@@ -81,7 +81,7 @@ app.Goals = {
       return "%";
     if (app.measurements.includes(stat))
       return (stat == "weight") ? units.weight : units.length;
-    if (checkPercentGoal && app.Goals.isPercentGoal(stat))
+    if (checkPercentGoal == true && app.Goals.isPercentGoal(stat))
       return "%"
     else
       return units[stat];
@@ -109,14 +109,14 @@ app.Goals = {
     let includesAutoAdjustGoal = false;
     let includesPercentGoal = false;
     stats.forEach((stat) => {
-      if (app.Goals.autoAdjustGoal(stat))
+      let statDateGoal = app.Goals.getStatDateGoal(stat, date);
+      if (statDateGoal["auto-adjust"] == true)
         includesAutoAdjustGoal = true;
-      if (app.Goals.isPercentGoal(stat))
+      if (statDateGoal["percent-goal"] == true)
         includesPercentGoal = true;
     });
 
-    let nutritionTotals = [];
-    let daysWithDiaryEntries = [];
+    let averageBasePeriodInfo = [];
     let energyGoals = [];
 
     // If some goals are defined to auto adjust, fetch the nutrition totals for the current average base period
@@ -130,20 +130,28 @@ app.Goals = {
         let diaryEntry = await app.Goals.getDiaryEntryFromDB(currentDate);
 
         if (diaryEntry !== undefined && diaryEntry.items !== undefined && diaryEntry.items.length > 0) {
-          let nutrition = await app.FoodsMealsRecipes.getTotalNutrition(diaryEntry.items);
-          nutritionTotals.push(nutrition);
-          daysWithDiaryEntries.push(currentDay);
+          let totalNutrition = await app.FoodsMealsRecipes.getTotalNutrition(diaryEntry.items);
+          let info = {
+            nutrition: totalNutrition,
+            date: currentDate,
+            day: currentDay
+          };
+          averageBasePeriodInfo.push(info);
         }
 
         // If some goals are defined as percentage of energy, also get the energy goal for each day of the current average base period
-        if (includesPercentGoal)
-          energyGoals.push(app.Goals.getGoal(energyName, currentDay, averageGoalBase, nutritionTotals, daysWithDiaryEntries));
+        if (includesPercentGoal) {
+          let energyGoal = app.Goals.getGoal(energyName, currentDate, currentDay, averageGoalBase, averageBasePeriodInfo);
+          energyGoals.push(energyGoal.goal);
+        }
       }
     }
 
-    // If some goals are defined as percentage of energy, also get the energy goal for the requested day
-    if (includesPercentGoal)
-      energyGoals.push(app.Goals.getGoal(energyName, day, averageGoalBase, nutritionTotals, daysWithDiaryEntries));
+    // If some goals are defined as percentage of energy, also get the energy goal for the requested date
+    if (includesPercentGoal) {
+      let energyGoal = app.Goals.getGoal(energyName, date, day, averageGoalBase, averageBasePeriodInfo);
+      energyGoals.push(energyGoal.goal);
+    }
 
     // Convert the energy goals to calories, if necessary
     if (energyUnit == app.nutrimentUnits.kilojoules) {
@@ -155,37 +163,37 @@ app.Goals = {
     // Get goals for the requested stats
     let goals = {};
     stats.forEach((stat) => {
-      goals[stat] = app.Goals.getGoal(stat, day, averageGoalBase, nutritionTotals, daysWithDiaryEntries, energyGoals);
+      goals[stat] = app.Goals.getGoal(stat, date, day, averageGoalBase, averageBasePeriodInfo, energyGoals);
     });
 
     return goals;
   },
 
-  getGoal: function(stat, day, averageGoalBase, nutritionTotals, daysWithDiaryEntries, energyGoals) {
+  getGoal: function(stat, date, day, averageGoalBase, averageBasePeriodInfo, energyGoals) {
     let energyGoal;
     if (energyGoals !== undefined)
-      energyGoal = energyGoals[energyGoals.length - 1]; // Last item in the list is for the requested day
+      energyGoal = energyGoals[energyGoals.length - 1]; // Last item in the list is for the requested date
 
-    let goal = app.Goals.getDayGoal(stat, day, energyGoal);
+    let statDateGoal = app.Goals.getStatDateGoal(stat, date);
+    let goal = app.Goals.getDayGoal(stat, statDateGoal, day, energyGoal);
 
-    if (app.Goals.autoAdjustGoal(stat)) {
+    if (statDateGoal["auto-adjust"] == true) {
       let statSum = 0;
       let goalSum = 0;
 
-      // Compute the sum of the nutrition intake for the current average base period
-      nutritionTotals.forEach((nutrition) => {
-        let dayStat = nutrition[stat] || 0;
+      // Compute the sums of the nutrition intake and of the nutrition goals for the current average base period
+      averageBasePeriodInfo.forEach((info, i) => {
+        let dayStat = info.nutrition[stat] || 0;
         statSum += dayStat;
-      });
 
-      // Compute the sum of the nutrition goals for the current average base period
-      daysWithDiaryEntries.forEach((d, i) => {
         let dayEnergyGoal;
         if (energyGoals !== undefined)
           dayEnergyGoal = energyGoals[i];
-        let dayGoal = app.Goals.getDayGoal(stat, d, dayEnergyGoal);
-        if (dayGoal !== undefined && dayGoal !== "")
-          goalSum += parseFloat(dayGoal);
+
+        let dateGoal = app.Goals.getStatDateGoal(stat, info.date);
+        let dayGoal = app.Goals.getDayGoal(stat, dateGoal, info.day, dayEnergyGoal);
+        if (dayGoal !== undefined && !isNaN(dayGoal))
+          goalSum += dayGoal;
       });
 
       // Split the difference among the remaining days of the current average base period
@@ -203,36 +211,42 @@ app.Goals = {
         goal = 0;
     }
 
-    return goal;
+    return {
+      goal: goal,
+      isMin: statDateGoal["minimum-goal"]
+    }
   },
 
-  getDayGoal: function(stat, day, energyGoal) {
-    let goals = app.Settings.get("goals", stat);
+  getDayGoal: function(stat, statGoal, day, energyGoal) {
+    let statGoalValues = statGoal["goal"] || [];
     let goal;
 
-    if (app.Goals.sharedGoal(stat) || app.measurements.includes(stat))
-      goal = parseFloat(goals[0]);
+    if (statGoal["shared-goal"] == true || app.measurements.includes(stat))
+      goal = parseFloat(statGoalValues[0]);
     else
-      goal = parseFloat(goals[day]);
+      goal = parseFloat(statGoalValues[day]);
 
-    if (app.Goals.isPercentGoal(stat))
+    if (statGoal["percent-goal"] == true)
       goal = app.Goals.getEnergyPercentGoal(stat, goal, energyGoal);
 
     return goal;
   },
 
   getAverageGoal: function(stat) {
-    let goals = app.Settings.get("goals", stat);
+    let statGoal = app.Goals.getStatDateGoal(stat);
+    let statGoalValues = statGoal["goal"] || [];
     let averageGoal;
 
-    if (app.Goals.sharedGoal(stat) || app.measurements.includes(stat)) {
-      averageGoal = parseFloat(goals[0]);
-    } else {
-      let goalSum = goals.reduce((a, b) => parseFloat(a) + parseFloat(b));
-      averageGoal = goalSum / 7;
+    if (statGoalValues.length) {
+      if (statGoal["shared-goal"] == true || app.measurements.includes(stat)) {
+        averageGoal = parseFloat(statGoalValues[0]);
+      } else {
+        let goalSum = statGoalValues.reduce((a, b) => parseFloat(a) + parseFloat(b));
+        averageGoal = goalSum / 7;
+      }
     }
 
-    if (app.Goals.isPercentGoal(stat)) {
+    if (statGoal["percent-goal"] == true) {
       const energyUnit = app.Settings.get("units", "energy");
       const energyName = app.Utils.getEnergyUnitName(energyUnit);
       let averageEnergyGoal = app.Goals.getAverageGoal(energyName);
@@ -249,10 +263,7 @@ app.Goals = {
   getEnergyPercentGoal: function(stat, percentGoal, energyGoal) {
     let caloriesPerUnit = app.Goals.getMacroNutrimentCalories(stat);
     let result = Math.round(percentGoal / 100 * energyGoal / caloriesPerUnit);
-
-    if (!isNaN(result))
-      return result;
-    return undefined;
+    return result;
   },
 
   getMacroNutrimentCalories: function(nutriment) {
@@ -276,40 +287,72 @@ app.Goals = {
     });
   },
 
+  getStatGoalSettings: function(stat) {
+    return app.Settings.get("goals", stat) || {};
+  },
+
+  getStatDateGoal: function(stat, date) {
+    let statGoalSettings = app.Goals.getStatGoalSettings(stat);
+    let statGoalList = statGoalSettings["goal-list"] || [];
+    if (statGoalList.length) {
+      statGoalList.reverse(); // Reverse list so last (= most recent) goal comes first
+      for (let goal of statGoalList) {
+        if (goal != undefined) {
+          if (date == undefined)
+            return goal; // Immediately return last (= most recent) goal from the list
+
+          if (goal.effectiveFrom != undefined) {
+            let effectiveFromDate = new Date(goal.effectiveFrom);
+            let requestedDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+            if (effectiveFromDate <= requestedDate)
+              return goal; // Return goal if it became effective before the requested date
+          } else {
+            return goal; // Goal has no effectiveFrom date so just return it
+          }
+        }
+      }
+    }
+    return {};
+  },
+
   showInDiary: function(stat) {
-    return app.Settings.get("goals", stat + "-show-in-diary");
+    let statGoalSettings = app.Goals.getStatGoalSettings(stat);
+    return statGoalSettings["show-in-diary"];
   },
 
   showInStats: function(stat) {
-    return app.Settings.get("goals", stat + "-show-in-stats");
+    let statGoalSettings = app.Goals.getStatGoalSettings(stat);
+    return statGoalSettings["show-in-stats"];
   },
 
-  sharedGoal: function(stat) {
-    return app.Settings.get("goals", stat + "-shared-goal");
+  sharedGoal: function(stat, date) {
+    let statDateGoal = app.Goals.getStatDateGoal(stat, date);
+    return statDateGoal["shared-goal"];
   },
 
-  autoAdjustGoal: function(stat) {
-    return app.Settings.get("goals", stat + "-auto-adjust");
+  autoAdjustGoal: function(stat, date) {
+    let statDateGoal = app.Goals.getStatDateGoal(stat, date);
+    return statDateGoal["auto-adjust"];
   },
 
-  isMinimumGoal: function(stat) {
-    return app.Settings.get("goals", stat + "-minimum-goal");
+  isMinimumGoal: function(stat, date) {
+    let statDateGoal = app.Goals.getStatDateGoal(stat, date);
+    return statDateGoal["minimum-goal"];
   },
 
-  isPercentGoal: function(stat) {
-    return app.Settings.get("goals", stat + "-percent-goal");
+  isPercentGoal: function(stat, date) {
+    let statDateGoal = app.Goals.getStatDateGoal(stat, date);
+    return statDateGoal["percent-goal"];
   },
 
   migrateStatGoalSettings: function(oldStat, newStat) {
     let goals = app.Settings.getField("goals");
 
-    ["", "-show-in-diary", "-show-in-stats", "-shared-goal", "-auto-adjust", "-minimum-goal", "-percent-goal"].forEach((setting) => {
-      if (oldStat + setting in goals) {
-        if (newStat !== undefined)
-          goals[newStat + setting] = goals[oldStat + setting];
-        delete goals[oldStat + setting];
-      }
-    });
+    if (oldStat in goals) {
+      if (newStat !== undefined)
+        goals[newStat] = goals[oldStat];
+      delete goals[oldStat];
+    }
 
     app.Settings.putField("goals", goals);
   }

--- a/www/activities/goals/views/goal-editor.html
+++ b/www/activities/goals/views/goal-editor.html
@@ -39,7 +39,7 @@
               <div class="item-title" data-localize="goal-editor.show-in-diary">Show in Diary</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" class="manual-bind" id="show-in-diary" field="goals" />
+                  <input type="checkbox" id="show-in-diary" />
                   <span class="toggle-icon"></span>
                 </label>
               </div>
@@ -53,9 +53,24 @@
               <div class="item-title" data-localize="goal-editor.show-in-stats">Show in Statistics</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" id="show-in-stats" field="goals" />
+                  <input type="checkbox" id="show-in-stats" />
                   <span class="toggle-icon"></span>
                 </label>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div class="list multi-line-titles">
+      <ul>
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
+              <div class="item-input-wrap input-dropdown-wrap">
+                <select id="select-goal">
+                </select>
               </div>
             </div>
           </div>
@@ -67,7 +82,7 @@
               <div class="item-title" data-localize="goal-editor.shared-goal">Same goal every day</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" class="manual-bind" id="shared-goal" field="goals" />
+                  <input type="checkbox" id="shared-goal" />
                   <span class="toggle-icon"></span>
                 </label>
               </div>
@@ -81,7 +96,7 @@
               <div class="item-title" data-localize="goal-editor.auto-adjust">Auto adjust to meet average goal</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" class="manual-bind" id="auto-adjust" field="goals" />
+                  <input type="checkbox" id="auto-adjust" />
                   <span class="toggle-icon"></span>
                 </label>
               </div>
@@ -95,7 +110,7 @@
               <div class="item-title" data-localize="goal-editor.minimum-goal">Is minimum goal</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" class="manual-bind" id="minimum-goal" field="goals" />
+                  <input type="checkbox" id="minimum-goal" />
                   <span class="toggle-icon"></span>
                 </label>
               </div>
@@ -109,7 +124,7 @@
               <div class="item-title" data-localize="goal-editor.percent-goal">Goal as percentage of energy intake</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" class="manual-bind" id="percent-goal" field="goals" />
+                  <input type="checkbox" id="percent-goal" />
                   <span class="toggle-icon"></span>
                 </label>
               </div>
@@ -123,7 +138,7 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-0">Sunday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
@@ -134,7 +149,7 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-1">Monday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
@@ -145,7 +160,7 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-2">Tuesday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
@@ -156,7 +171,7 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-3">Wednesday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
@@ -167,7 +182,7 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-4">Thursday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
@@ -178,7 +193,7 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-5">Friday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
@@ -189,10 +204,14 @@
             <div class="item-inner">
               <div class="item-title item-label" id="goal-6">Saturday</div>
               <div class="item-input-wrap">
-                <input type="number" min="0" step="any" field="goals">
+                <input type="number" min="0" step="any">
               </div>
             </div>
           </div>
+        </li>
+
+        <li>
+          <a class="list-button" id="delete-goal" data-localize="goal-editor.delete-goal">Delete Goal</a>
         </li>
       </ul>
     </div>

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -19,7 +19,7 @@
 
 // After a breaking change to the settings schema, increment this constant
 // and implement the migration in the migrateSettings() function below
-const currentSettingsSchemaVersion = 4;
+const currentSettingsSchemaVersion = 5;
 
 var s;
 app.Settings = {
@@ -363,6 +363,7 @@ app.Settings = {
                   let settings = app.Settings.migrateSettings(data.settings, false);
                   window.localStorage.setItem("settings", JSON.stringify(settings));
                   this.changeTheme(settings.appearance["dark-mode"], settings.appearance["theme"]);
+                  app.f7.views.main.router.refreshPage();
                 }
               }
             }
@@ -516,28 +517,49 @@ app.Settings = {
         length: "cm"
       },
       goals: {
+        migrated: true,
         "first-day-of-week": "0",
         "average-goal-base": "week",
-        calories: ["2000", "", "", "", "", "", ""],
-        "calories-shared-goal": true,
-        "calories-show-in-diary": true,
-        "calories-show-in-stats": true,
-        kilojoules: ["8400", "", "", "", "", "", ""],
-        "kilojoules-shared-goal": true,
-        "kilojoules-show-in-diary": true,
-        "kilojoules-show-in-stats": true,
-        proteins: ["50", "", "", "", "", "", ""],
-        "proteins-shared-goal": true,
-        "proteins-show-in-diary": true,
-        "proteins-show-in-stats": true,
-        carbohydrates: ["250", "", "", "", "", "", ""],
-        "carbohydrates-shared-goal": true,
-        "carbohydrates-show-in-diary": true,
-        "carbohydrates-show-in-stats": true,
-        fat: ["65", "", "", "", "", "", ""],
-        "fat-shared-goal": true,
-        "fat-show-in-diary": true,
-        "fat-show-in-stats": true,
+        kilojoules: {
+          "show-in-diary": true,
+          "show-in-stats": true,
+          "goal-list": [{
+            "shared-goal": true,
+            "goal": ["8400", "", "", "", "", "", ""]
+          }]
+        },
+        calories: {
+          "show-in-diary": true,
+          "show-in-stats": true,
+          "goal-list": [{
+            "shared-goal": true,
+            "goal": ["2000", "", "", "", "", "", ""]
+          }]
+        },
+        fat: {
+          "show-in-diary": true,
+          "show-in-stats": true,
+          "goal-list": [{
+            "shared-goal": true,
+            "goal": ["70", "", "", "", "", "", ""]
+          }]
+        },
+        carbohydrates: {
+          "show-in-diary": true,
+          "show-in-stats": true,
+          "goal-list": [{
+            "shared-goal": true,
+            "goal": ["260", "", "", "", "", "", ""]
+          }]
+        },
+        proteins: {
+          "show-in-diary": true,
+          "show-in-stats": true,
+          "goal-list": [{
+            "shared-goal": true,
+            "goal": ["50", "", "", "", "", "", ""]
+          }]
+        }
       },
       nutriments: {
         order: ["kilojoules", "calories", "fat", "saturated-fat", "carbohydrates", "sugars", "fiber", "proteins", "salt", "monounsaturated-fat", "polyunsaturated-fat", "trans-fat", "omega-3-fat", "omega-6-fat", "omega-9-fat", "cholesterol", "sodium", "vitamin-a", "vitamin-d", "vitamin-e", "vitamin-k", "vitamin-c", "vitamin-b1", "vitamin-b2", "vitamin-pp", "pantothenic-acid", "vitamin-b6", "biotin", "vitamin-b9", "vitamin-b12", "potassium", "chloride", "calcium", "phosphorus", "iron", "magnesium", "zinc", "copper", "manganese", "fluoride", "selenium", "iodine", "caffeine", "alcohol", "sucrose", "glucose", "fructose", "lactose"],
@@ -587,6 +609,15 @@ app.Settings = {
         settings.goals["average-goal-base"] = "week";
       }
 
+      // Goals must be migrated to new format
+      if (settings.goals !== undefined && settings.goals.migrated === undefined) {
+        let oldGoals = settings.goals;
+        let nutriments = app.nutriments;
+        if (settings.nutriments !== undefined && settings.nutriments.order !== undefined)
+          nutriments = settings.nutriments.order;
+        settings.goals = app.Settings.migrateGoalSettings(oldGoals, nutriments);
+      }
+
       settings.schemaVersion = currentSettingsSchemaVersion;
 
       if (saveChanges)
@@ -594,6 +625,49 @@ app.Settings = {
     }
 
     return settings;
+  },
+
+  migrateGoalSettings: function (oldGoals, nutriments) {
+
+    let newGoals = {
+      migrated: true
+    };
+
+    for (let key in oldGoals) {
+      for (let setting of ["first-day-of-week", "average-goal-base"]) {
+        if (key == setting) {
+          newGoals[setting] = oldGoals[key];
+          continue;
+        }
+      }
+      for (let setting of ["-show-in-diary", "-show-in-stats"]) {
+        if (key.endsWith(setting)) {
+          let stat = key.replace(setting, "");
+          let settingName = setting.substring(1);
+          newGoals[stat] = newGoals[stat] || {};
+          newGoals[stat][settingName] = oldGoals[key];
+          continue;
+        }
+      }
+      for (let setting of ["-shared-goal", "-auto-adjust", "-minimum-goal", "-percent-goal"]) {
+        if (key.endsWith(setting)) {
+          let stat = key.replace(setting, "");
+          let settingName = setting.substring(1);
+          newGoals[stat] = newGoals[stat] || {};
+          newGoals[stat]["goal-list"] = newGoals[stat]["goal-list"] || [{}];
+          newGoals[stat]["goal-list"][0][settingName] = oldGoals[key];
+          continue;
+        }
+      }
+      if (nutriments.includes(key)) {
+        newGoals[key] = newGoals[key] || {};
+        newGoals[key]["goal-list"] = newGoals[key]["goal-list"] || [{}];
+        newGoals[key]["goal-list"][0]["goal"] = oldGoals[key];
+        continue;
+      }
+    }
+
+    return newGoals;
   }
 };
 

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -193,7 +193,11 @@
     "shared-goal": "Same goal every day",
     "auto-adjust": "Auto adjust to meet average goal",
     "minimum-goal": "Is minimum goal",
-    "percent-goal": "Goal as percentage of energy intake"
+    "percent-goal": "Goal as percentage of energy intake",
+    "effective-from": "Effective from",
+    "new-goal": "New Goal",
+    "delete-goal": "Delete Goal",
+    "goal-deleted": "Goal Deleted"
   },
   "meal-editor": {
     "title": "Edit Meal",


### PR DESCRIPTION
This PR adds the ability to set new nutrition goals without overwriting your previous goals (closes #519).

To do this, I completely reworked the way nutrition goals are stored by the app. Instead of

```json
"goals": {
  "calories": ["2000", "", "", "", "", "", ""],
  "calories-shared-goal": true,
  "calories-show-in-diary": true,
  "calories-show-in-stats": true,
  ...
},
```

you can now have a whole list of goals per nutrient:

```json
"goals": {
  "calories": {
    "show-in-diary": true,
    "show-in-stats": true,
    "goal-list": [{
        "shared-goal": true,
        "goal": ["2000", "", "", "", "", "", ""]
      },
      {
        "effectiveFrom": "2022-03-26T00:00:00.000Z",
        "shared-goal": true,
        "auto-adjust": true,
        "goal": ["2200", "", "", "", "", "", ""]
    }]
  },
  ...
},
```

The goals in the list may have an `effectiveFrom` date that is used to determine which goal should be used on a given day.