### PR TITLE
Remove character limit for quick-add descriptions

### DIFF
--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -154,7 +154,7 @@ app.OpenFoodFacts = {
     } else if (dataAvailablePer100g === true) {
       result.portion = "100";
       result.unit = app.strings["unit-symbols"]["g"] || "g";
-      if (item.serving_size && item.serving_size.match(/\d\s*(ml|cl|l)/i))
+      if (item.serving_size && item.serving_size.match(/\d\s*(ml|cl|l)(\s|$)/i))
         result.unit = app.strings["unit-symbols"]["ml"] || "ml";
       if (item.nutriments.energy_100g) {
         result.nutrition.calories = (item.nutriments["energy-kcal_100g"]) ?

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -481,7 +481,7 @@ app.FoodsMealsRecipes = {
         title.className = "item-title";
         if (item.name == "Quick Add") {
           if (item.description !== undefined)
-            title.innerText = app.Utils.tidyText(item.description, 50);
+            title.innerText = item.description;
           else
             title.innerText = app.strings.diary["quick-add"] || "Quick Add";
         } else {


### PR DESCRIPTION
This removes the somewhat arbitrary limit of 50 characters for quick-add descriptions to make them more useful for taking notes as discussed in #543.