### PR TITLE
Add ability to show goal progress and remaining nutrition allowance in diary bottom bar

### DIFF
--- a/metadata/en-US/changelogs/30401.txt
+++ b/metadata/en-US/changelogs/30401.txt
@@ -1,4 +1,5 @@
 - you can now add items to the diary or a meal/recipe by scanning their barcodes
+- tap on the diary bottom bar to see your remaining allowance and goal progress
 - added support for Ukrainian language
 - various bugfixes
 

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -306,11 +306,11 @@ app.Diary = {
       remaining.className = "col";
       remaining.id = x + "-remaining";
 
-      let remainingSpan = document.createElement("span");
       let progressCanvas = document.createElement("canvas");
       progressCanvas.style.display = "inline";
       progressCanvas.style.width = "0";
       progressCanvas.style.height = "0";
+      let remainingSpan = document.createElement("span");
       let remainingText = document.createTextNode("");
 
       // Value colour and goal
@@ -362,7 +362,6 @@ app.Diary = {
             backgroundColours.push("dimgrey");
         }
 
-        progressCanvas.style.margin = "0.2em 0.5em 0";
         progressCanvas.style.width = "2em";
         progressCanvas.style.height = "1em";
 
@@ -403,8 +402,8 @@ app.Diary = {
       rows[1].appendChild(values);
 
       remainingSpan.appendChild(remainingText);
-      remaining.appendChild(remainingSpan);
       remaining.appendChild(progressCanvas);
+      remaining.appendChild(remainingSpan);
       rows[2].appendChild(remaining);
 
       count++;

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -286,7 +286,7 @@ app.Diary = {
 
       // Value
       let values = document.createElement("div");
-      values.className = "col keep-ltr";
+      values.className = "col";
       values.id = x + "-value";
 
       let valueSpan = document.createElement("span");

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -59,6 +59,7 @@ app.Diary = {
     app.Diary.el.log = document.querySelector(".page[data-name='diary'] #log");
     app.Diary.el.date = document.querySelector(".page[data-name='diary'] #diary-date");
     app.Diary.el.showChart = document.querySelector(".page[data-name='diary'] #show-chart");
+    app.Diary.el.diaryNutrition = document.querySelector(".page[data-name='diary'] #diary-nutrition");
   },
 
   bindUIActions: function() {
@@ -71,12 +72,26 @@ app.Diary = {
       app.Diary.el.log.hasClickEvent = true;
     }
 
-    // Show chart 
+    // Show chart
     if (!app.Diary.el.showChart.hasClickEvent) {
       app.Diary.el.showChart.addEventListener("click", (e) => {
         app.Diary.showChart();
       });
       app.Diary.el.showChart.hasClickEvent = true;
+    }
+
+    // Toggle nutrition swiper card
+    if (!app.Diary.el.diaryNutrition.hasClickEvent) {
+      app.Diary.el.diaryNutrition.addEventListener("click", (e) => {
+        if (app.Diary.el.diaryNutrition.classList.contains("show-values")) {
+          app.Diary.el.diaryNutrition.classList.remove("show-values");
+          app.Diary.el.diaryNutrition.classList.add("show-remaining");
+        } else {
+          app.Diary.el.diaryNutrition.classList.remove("show-remaining");
+          app.Diary.el.diaryNutrition.classList.add("show-values");
+        }
+      });
+      app.Diary.el.diaryNutrition.hasClickEvent = true;
     }
   },
 
@@ -253,6 +268,10 @@ app.Diary = {
         rows[1] = document.createElement("div");
         rows[1].className = "row nutrition-total-values";
         slide.appendChild(rows[1]);
+
+        rows[2] = document.createElement("div");
+        rows[2].className = "row nutrition-total-remaining";
+        slide.appendChild(rows[2]);
       }
 
       // Title
@@ -270,8 +289,8 @@ app.Diary = {
       values.className = "col keep-ltr";
       values.id = x + "-value";
 
-      let span = document.createElement("span");
-      t = document.createTextNode("");
+      let valueSpan = document.createElement("span");
+      let valueText = document.createTextNode("");
       let value = 0;
 
       if (nutrition !== undefined && nutrition[x] !== undefined) {
@@ -280,30 +299,113 @@ app.Diary = {
         else
           value = (Math.round(nutrition[x]));
       }
-      t.nodeValue = app.Utils.tidyNumber(value);
+      valueText.nodeValue = app.Utils.tidyNumber(value);
+
+      // Remaining and progress
+      let remaining = document.createElement("div");
+      remaining.className = "col";
+      remaining.id = x + "-remaining";
+
+      let remainingSpan = document.createElement("span");
+      let progressCanvas = document.createElement("canvas");
+      progressCanvas.style.display = "inline";
+      progressCanvas.style.width = "0";
+      progressCanvas.style.height = "0";
+      let remainingText = document.createTextNode("");
 
       // Value colour and goal
       let goal = nutrimentGoal.goal;
       let isMin = nutrimentGoal.isMin;
 
       if (goal !== undefined && !isNaN(goal)) {
-        if ((isMin !== true && value > goal) || (isMin === true && value < goal))
-          span.style.color = "red";
-        else
-          span.style.color = "green";
+        let colour;
 
-        t.nodeValue += " / " + app.Utils.tidyNumber(Math.round(goal * 100) / 100);
+        if ((isMin !== true && value > goal) || (isMin === true && value < goal))
+          colour = "red";
+        else
+          colour = "green";
+
+        valueSpan.style.color = colour;
+        remainingSpan.style.color = colour;
+
+        // Goal
+        valueText.nodeValue += " / " + app.Utils.tidyNumber(Math.round(goal * 100) / 100);
+
+        // Remaining value
+        let remainingValue = Math.round((value - goal) * 100) / 100;
+        if (remainingValue > 0)
+          remainingText.nodeValue = "\u200E+" + app.Utils.tidyNumber(remainingValue);
+        else
+          remainingText.nodeValue = app.Utils.tidyNumber(remainingValue);
+
+        // Progress ring
+        let percentProgress = value / goal;
+        let overshot = false;
+        if (percentProgress > 1) {
+          overshot = true;
+          if (percentProgress < 2)
+            percentProgress -= 1;
+          else
+            percentProgress = 1;
+        }
+
+        // Progress ring colours
+        let backgroundColours = [];
+        if (overshot) {
+          backgroundColours.push(colour);
+          backgroundColours.push(Chart.defaults.global.defaultFontColor);
+        } else {
+          backgroundColours.push(Chart.defaults.global.defaultFontColor);
+          if (Chart.defaults.global.defaultFontColor == "black")
+            backgroundColours.push("lightgrey");
+          else
+            backgroundColours.push("dimgrey");
+        }
+
+        progressCanvas.style.margin = "0.2em 0.5em 0";
+        progressCanvas.style.width = "2em";
+        progressCanvas.style.height = "1em";
+
+        // Draw progress ring
+        let chart = new Chart(progressCanvas, {
+          type: "doughnut",
+          data: {
+            datasets: [{
+              data: [percentProgress, (1 - percentProgress)],
+              backgroundColor: backgroundColours,
+              borderWidth: 0
+            }]
+          },
+          options: {
+            cutoutPercentage: 60,
+            responsive: false,
+            tooltips: {
+              enabled: false
+            },
+            animation: {
+              animateRotate: false
+            }
+          }
+        });
+      } else {
+        remainingText.nodeValue = app.Utils.tidyNumber(value);
       }
 
       // Unit
       if (app.Settings.get("diary", "show-nutrition-units")) {
         let unit = app.strings["unit-symbols"][units[x]] || units[x];
-        t.nodeValue += app.Utils.tidyNumber(undefined, unit);
+        valueText.nodeValue += app.Utils.tidyNumber(undefined, unit);
+        remainingText.nodeValue += app.Utils.tidyNumber(undefined, unit);
       }
 
-      span.appendChild(t);
-      values.appendChild(span);
+      valueSpan.appendChild(valueText);
+      values.appendChild(valueSpan);
       rows[1].appendChild(values);
+
+      remainingSpan.appendChild(remainingText);
+      remaining.appendChild(remainingSpan);
+      remaining.appendChild(progressCanvas);
+      rows[2].appendChild(remaining);
 
       count++;
     });

--- a/www/activities/diary/views/diary.css
+++ b/www/activities/diary/views/diary.css
@@ -27,5 +27,8 @@
 .page[data-name="diary"] #diary-nutrition .col {text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;}
 .page[data-name="diary"] #diary-nutrition .nutrition-total-title {font-weight: bold;}
 
+.page[data-name="diary"] #diary-nutrition.show-values .nutrition-total-remaining {display: none;}
+.page[data-name="diary"] #diary-nutrition.show-remaining .nutrition-total-values {display: none;}
+
 /* Dialog with scrollbar */
 .scroll-dialog {max-height: 64vh; overflow-y: auto;}

--- a/www/activities/diary/views/diary.html
+++ b/www/activities/diary/views/diary.html
@@ -56,7 +56,7 @@
 	</div>
 
 	<div class="toolbar toolbar-bottom">
-		<div class="toolbar-inner" id="diary-nutrition">
+		<div class="toolbar-inner ripple show-values" id="diary-nutrition">
 			<div class="swiper-container swiper-init">
 				<div class="swiper-wrapper" style="height: auto;"></div>
 			</div>

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -435,10 +435,14 @@ app.Foodlist = {
                 if (item !== undefined && item.id !== undefined)
                   result[0].id = item.id;
 
-                if (result !== undefined && result[0] !== undefined)
+                if (result !== undefined && result[0] !== undefined) {
                   item = result[0];
-                else if (app.FoodsMealsRecipes.editItems != "disabled")
+                } else if (app.FoodsMealsRecipes.editItems != "disabled") {
                   app.Foodlist.gotoUploadEditor(code);
+                } else {
+                  let msg = app.strings.dialogs["no-results"] || "No matching results";
+                  app.Utils.toast(msg);
+                }
               }
             }
             resolve(item);

--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -154,7 +154,7 @@ app.OpenFoodFacts = {
     } else if (dataAvailablePer100g === true) {
       result.portion = "100";
       result.unit = app.strings["unit-symbols"]["g"] || "g";
-      if (item.serving_size && item.serving_size.match(/\d\s*(ml|cl|l)(\s|$)/i))
+      if (item.serving_size && item.serving_size.match(/\d\s*(ml|cl|l)(\s|\)|\]|,|;|$)/i))
         result.unit = app.strings["unit-symbols"]["ml"] || "ml";
       if (item.nutriments.energy_100g) {
         result.nutrition.calories = (item.nutriments["energy-kcal_100g"]) ?

--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -27,8 +27,6 @@ option {direction: ltr;}
 html[dir="rtl"] select.align-end {direction: ltr;}
 html[dir="rtl"] option {direction: rtl;}
 
-.keep-ltr {direction: ltr;}
-
 #categories { width: 100%; }
 #categories-list:not([disabled]) { color: inherit; }
 

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -31,7 +31,7 @@ app.Utils = {
   tidyNumber: function(number, unit) {
     let text = "";
     if (number !== undefined) {
-      text += number.toLocaleString([], { useGrouping: false }).replace("-", "\u2212");
+      text += "\u200E" + number.toLocaleString([], { useGrouping: false }).replace("-", "\u2212");
     }
     if (unit !== undefined) {
       if (app.standardUnits.includes(unit))


### PR DESCRIPTION
This PR adds the ability to see your goal progress and remaining nutrition allowance in the diary bottom bar.

Here is an example of the diary bottom bar where
- the carbs goal has not been reached yet,
- the sugars goal has already been overshot, and
- the fiber goal has also been overshot (but it's a minimum goal, so that's a good thing)

![localhost_](https://user-images.githubusercontent.com/19289477/164931603-09e06eaf-8693-45ae-b144-a05f44124d12.png)

If you toggle the view by tapping on the diary bottom bar, it shows this:
- the carbs goal is about 90% complete (you need another 35.56g of carbs to reach it),
- the sugars goal has been overshot by about 40%, (you ate 42.6g too much) and
- the fiber goal has been overshot by about 10% (you ate 3.2g too much, but that's a good thing)

![localhost_ (1)](https://user-images.githubusercontent.com/19289477/164931748-d997e1da-1e26-4ccf-9b37-52fb8339d883.png)

And this is how it looks in dark mode:

![localhost_ (2)](https://user-images.githubusercontent.com/19289477/164931686-2ee6c266-dacf-4bf6-8460-ab879d0ecacb.png)

You can toggle between the views by tapping on the bottom bar. This does not interfere with the ability to swipe left and right.

Closes #565. Closes #442. Closes #324.