### PR TITLE
Improve handling of food selection

### DIFF
--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -27,7 +27,7 @@ app.Foodlist = {
 
     if (context && context.item) {
       await this.putItem(context.item);
-      app.FoodsMealsRecipes.clearSearchSelection();
+      app.FoodsMealsRecipes.unselectOldItem(context.item);
     }
 
     this.getComponents();

--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -313,47 +313,29 @@ app.Foodlist = {
     });
   },
 
-  submitButtonAction: async function(selection) {
-    let data = await this.getItemsFromSelection(selection);
-    app.FoodsMealsRecipes.returnItems(data.items);
-  },
-
-  getItemsFromSelection: function(selection) {
+  getItemFromSelectedData: function(data) {
     return new Promise(async function(resolve, reject) {
-      let result = {
-        items: [],
-        ids: []
-      };
+      if (data.id == undefined || data.hidden == true) { // No ID or hidden, must be a search result
 
-      for (let i = 0; i < selection.length; i++) {
-        let data = JSON.parse(selection[i]);
+        if (data.barcode) { // If item has barcode it must be from online service or imported from JSON
 
-        if (data.id == undefined || data.hidden == true) { //No ID or hidden, must be a search result 
+          // Check to see if item is already in DB
+          let dbData = await app.Foodlist.searchByBarcode(data.barcode);
 
-          if (data.barcode) { //If item has barcode it must be from online service or imported from JSON
-
-            //Check to see if item is already in DB 
-            let dbData = await app.Foodlist.searchByBarcode(data.barcode);
-
-            //If item is in DB use retrieved data, otherwise add item to DB and get new ID
-            if (dbData) {
-              data = dbData;
-              data.archived = false; // Unarchive the food if it has been archived
-              if (data.hidden == true) data.hidden = false; // Unhide the food if it was imported from JSON
-              await app.Foodlist.putItem(data);
-            }
+          // If item is in DB use retrieved data
+          if (dbData) {
+            data = dbData;
+            data.archived = false; // Unarchive the food if it has been archived
+            if (data.hidden == true) data.hidden = false; // Unhide the food if it was imported from JSON
+            await app.Foodlist.putItem(data);
           }
-
-          // Doesn't have barcode or could not be found with barcode search
-          if (data.id == undefined)
-            data.id = await app.Foodlist.putItem(data);
         }
 
-        result.items.push(data);
-        result.ids.push(data.id);
+        // Item is not in DB or doesn't have barcode, add to DB and get new ID
+        if (data.id == undefined)
+          data.id = await app.Foodlist.putItem(data);
       }
-
-      resolve(result);
+      resolve(data);
     });
   },
 

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -604,6 +604,15 @@ app.FoodsMealsRecipes = {
     }
   },
 
+  clearSelection: function() {
+    const checked = Array.from(document.querySelectorAll('input[type=checkbox]:checked'));
+    checked.forEach((x) => {
+      x.checked = false;
+    });
+    app.FoodsMealsRecipes.selection = [];
+    app.FoodsMealsRecipes.updateSelectionCount();
+  },
+
   unselectOldItem: function(item) {
     // Iterate over all selected items in the current view
     const checked = Array.from(document.querySelectorAll('input[type=checkbox]:checked'));

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -564,15 +564,13 @@ app.FoodsMealsRecipes = {
   },
 
   checkboxChanged: function(state, item) {
-
     if (state === true) {
       app.FoodsMealsRecipes.selection.push(item);
     } else {
-      let itemIndex = app.FoodsMealsRecipes.selection.indexOf(item);
-      if (itemIndex != -1)
-        app.FoodsMealsRecipes.selection.splice(itemIndex, 1);
+      let index = app.FoodsMealsRecipes.selection.indexOf(item);
+      if (index != -1)
+        app.FoodsMealsRecipes.selection.splice(index, 1);
     }
-
     app.FoodsMealsRecipes.updateSelectionCount();
   },
 
@@ -633,10 +631,6 @@ app.FoodsMealsRecipes = {
     $(".page-content").scrollTop(0);
     app.f7.searchbar.disable(searchForm);
     app.FoodsMealsRecipes.clearSelectedCategories(searchFilter, searchFilterIcon);
-  },
-
-  getSelection: function() {
-    return app.FoodsMealsRecipes.selection;
   },
 
   initializeSearchBar: function(element, eventHandlers) {

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -604,17 +604,19 @@ app.FoodsMealsRecipes = {
     }
   },
 
-  clearSearchSelection: function() {
-
-    //Remove any selected search items from the selection array
+  unselectOldItem: function(item) {
+    // Iterate over all selected items in the current view
     const checked = Array.from(document.querySelectorAll('input[type=checkbox]:checked'));
-
-    checked.forEach((x, i) => {
-      let itemIndex = app.FoodsMealsRecipes.selection.indexOf(x.data);
-      if (itemIndex != -1)
-        app.FoodsMealsRecipes.selection.splice(itemIndex, 1);
+    checked.forEach((x) => {
+      let data = JSON.parse(x.data);
+      // Check if the item id or barcode matches the selected data
+      if ((data.id !== undefined && data.id === item.id) || (data.barcode !== undefined && data.barcode === item.barcode)) {
+        // They match -> remove the old item from the selection because it was just edited
+        let index = app.FoodsMealsRecipes.selection.indexOf(x.data);
+        if (index != -1)
+          app.FoodsMealsRecipes.selection.splice(index, 1);
+      }
     });
-
     app.FoodsMealsRecipes.updateSelectionCount();
   },
 

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -210,19 +210,6 @@ app.Meals = {
     }).open();
   },
 
-  submitButtonAction: function(selection) {
-    let result = [];
-
-    selection.forEach((x) => {
-      let meal = JSON.parse(x);
-      meal.items.forEach((f) => {
-        result.push(f);
-      });
-    });
-
-    app.FoodsMealsRecipes.returnItems(result);
-  },
-
   gotoEditor: function(meal) {
     app.data.context = {
       meal: meal,

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -25,8 +25,8 @@ app.Meals = {
 
   init: async function(context) {
 
-    if (context)
-      app.FoodsMealsRecipes.clearSearchSelection();
+    if (context && context.meal)
+      app.FoodsMealsRecipes.unselectOldItem(context.meal);
 
     app.Meals.getComponents();
     app.Meals.createSearchBar();

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -25,8 +25,8 @@ app.Recipes = {
 
   init: async function(context) {
 
-    if (context)
-      app.FoodsMealsRecipes.clearSearchSelection();
+    if (context && context.recipe)
+      app.FoodsMealsRecipes.unselectOldItem(context.recipe);
 
     app.Recipes.getComponents();
     app.Recipes.createSearchBar();

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -156,18 +156,6 @@ app.Recipes = {
     }).open();
   },
 
-  submitButtonAction: function(selection) {
-    let result = [];
-
-    selection.forEach((x) => {
-      let recipe = JSON.parse(x);
-      recipe.type = "recipe";
-      result.push(recipe);
-    });
-
-    app.FoodsMealsRecipes.returnItems(result);
-  },
-
   gotoEditor: function(recipe) {
     app.data.context = {
       recipe: recipe,

--- a/www/index.js
+++ b/www/index.js
@@ -519,6 +519,12 @@ document.addEventListener("backbutton", (e) => {
     return false;
   }
 
+  let selection = app.FoodsMealsRecipes.selection;
+  if (searchField && selection && selection.length) {
+    app.FoodsMealsRecipes.clearSelection();
+    return false;
+  }
+
   let history = new Set(app.f7.views.main.history);
   if (history.size > 1) {
     app.f7.views.main.router.back();


### PR DESCRIPTION
This PR improves the selection handling in the food list:
- The selection is now kept when switching between the foods/meals/recipes tabs.
- You can clear the selection by pressing the hardware back button.
- If you edit an item that was already selected, the old item gets removed from the selection (before, it would remove all current items from the selection, not just the edited item).

Closes #569.