### PR TITLE
Fix removable food images in the diary

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -459,7 +459,8 @@ app.FoodEditor = {
             }
           }
         } else {
-          app.FoodEditor.insertImageEl(0, item.image_url, true);
+          let removable = (app.FoodEditor.origin == "foodlist");
+          app.FoodEditor.insertImageEl(0, item.image_url, removable);
         }
       }
     } else if (app.FoodEditor.origin == "foodlist") {


### PR DESCRIPTION
This fixes a minor bug where custom food images were removable when editing items in the diary.