### PR TITLE
Add "Set Goals" button on Goals settings page

### DIFF
--- a/www/activities/settings/views/goals.html
+++ b/www/activities/settings/views/goals.html
@@ -66,6 +66,12 @@
             </div>
           </div>
         </li>
+
+        <li>
+          <a href="/goals/" class="item-link item-content">
+            <div class="item-inner" data-localize="goal-editor.title">Set Goals</div>
+          </a>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This adds a "Set Goals" button under `Setttings > Goals` as suggested in https://github.com/davidhealey/waistline/issues/589#issuecomment-1148834749. Tapping the button takes you directly to the Goals page. Closes #589.