### PR TITLE
Add option to follow the system wide dark theme (Android 10+)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -20,6 +20,8 @@
         <preference name="AndroidPersistentFileLocation" value="Compatibility" />
         <preference name="AndroidExtraFilesystems" value="files,sdcard,cache" />
         <preference name="AndroidInsecureFileModeEnabled" value="true" />
+        <preference name="AndroidXEnabled" value="true" />
+        <preference name="GradlePluginKotlinEnabled" value="true" />
         <config-file after="uses-permission" parent="/manifest" target="AndroidManifest.xml">
           <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
           <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/metadata/en-US/changelogs/30403.txt
+++ b/metadata/en-US/changelogs/30403.txt
@@ -1,3 +1,4 @@
+- added option to follow the system wide dark theme (Android 10+)
 - clarified that foods and recipes cannot be deleted, only archived
 - added ability to browse archived foods and recipes
 - added ability to clone an existing food, meal or recipe

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cordova-android": "^10.1.2",
     "cordova-browser": "^6.0.0",
     "cordova-electron": "^3.0.0",
+    "cordova-plugin-android-dark-mode-support": "^1.0.0",
     "cordova-plugin-browsersync-gen2": "^1.1.7",
     "cordova-plugin-camera": "^6.0.0",
     "cordova-plugin-chooser": "^1.3.2",
@@ -36,7 +37,8 @@
       "cordova-plugin-inappbrowser": {},
       "cordova-plugin-ionic-keyboard": {},
       "cordova-plugin-chooser": {},
-      "cordova-plugin-crop": {}
+      "cordova-plugin-crop": {},
+      "cordova-plugin-android-dark-mode-support": {}
     },
     "platforms": [
       "browser",

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -523,7 +523,7 @@ app.Settings = {
         usda: false
       },
       appearance: {
-        mode: "system",
+        mode: "light",
         theme: "color-theme-red",
         animations: false,
         locale: "auto",

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -167,41 +167,43 @@ app.Settings = {
     // Dark mode
     let darkMode = document.querySelector(".page[data-name='settings-appearance'] #dark-mode");
 
-    if (darkMode != undefined && !darkMode.hasClickEvent) {
-      darkMode.addEventListener("click", (e) => {
+    if (darkMode != undefined && !darkMode.hasSecondaryChangeEvent) {
+      darkMode.addEventListener("change", (e) => {
         app.Settings.changeTheme(e.target.checked, themeSelect.value);
       });
-      darkMode.hasClickEvent = true;
+      darkMode.hasSecondaryChangeEvent = true;
     }
 
     // Theme
     let themeSelect = document.querySelector(".page[data-name='settings-appearance'] #theme");
 
-    if (themeSelect != undefined && !themeSelect.hasChangeEvent) {
+    if (themeSelect != undefined && !themeSelect.hasSecondaryChangeEvent) {
       themeSelect.addEventListener("change", (e) => {
         app.Settings.changeTheme(darkMode.checked, e.target.value);
       });
-      themeSelect.hasChangeEvent = true;
+      themeSelect.hasSecondaryChangeEvent = true;
     }
 
     // Preferred Language
     let locale = document.querySelector(".page[data-name='settings-appearance'] #locale");
 
-    if (locale != undefined && !locale.hasChangeEvent) {
+    if (locale != undefined && !locale.hasSecondaryChangeEvent) {
       locale.addEventListener("change", (e) => {
         let msg = app.strings.settings["needs-restart"] || "Restart app to apply changes.";
         app.Utils.toast(msg);
       });
-      locale.hasChangeEvent = true;
+      locale.hasSecondaryChangeEvent = true;
     }
 
     // Animations 
-    let toggleAnimations = document.getElementById("toggle-animations");
-    if (toggleAnimations != undefined) {
-      toggleAnimations.addEventListener("click", (e) => {
+    let toggleAnimations = document.querySelector(".page[data-name='settings-appearance'] #toggle-animations");
+
+    if (toggleAnimations != undefined && !toggleAnimations.hasSecondaryChangeEvent) {
+      toggleAnimations.addEventListener("change", (e) => {
         let msg = app.strings.settings["needs-restart"] || "Restart app to apply changes.";
         app.Utils.toast(msg);
       });
+      toggleAnimations.hasSecondaryChangeEvent = true;
     }
 
     // Nutriment list 

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -234,31 +234,30 @@ app.Settings = {
   },
 
   changeTheme: function(appMode, colourTheme) {
-    let html = document.getElementsByTagName("html")[0];
     let body = document.getElementsByTagName("body")[0];
-    let panel = document.getElementById("app-panel");
-
-    isDark = false;
+    body.className = colourTheme;
 
     if (appMode === "system") {
-      app.f7.enableAutoDarkTheme();
-      isDark = (app.f7.darkTheme === true);
+      app.f7.enableAutoDarkTheme(); // darkThemeChange event will handle the rest
     } else {
       app.f7.disableAutoDarkTheme();
-      isDark = (appMode === "dark");
+      app.Settings.applyAppMode(appMode);
     }
+  },
 
-    if (isDark) {
+  applyAppMode: function(appMode) {
+    let html = document.getElementsByTagName("html")[0];
+    let panel = document.getElementById("app-panel");
+
+    if (appMode === "dark") {
       html.classList.add("theme-dark");
       panel.style["background-color"] = "black";
       Chart.defaults.global.defaultFontColor = "white";
-    } else {
+    } else if (appMode === "light") {
       html.classList.remove("theme-dark");
       panel.style["background-color"] = "white";
       Chart.defaults.global.defaultFontColor = "black";
     }
-
-    body.className = colourTheme;
   },
 
   saveInputs: function(inputs) {

--- a/www/activities/settings/views/appearance.html
+++ b/www/activities/settings/views/appearance.html
@@ -32,14 +32,15 @@
     <div class="list multi-line-titles">
       <ul>
         <li>
-          <div class="item-content">
+          <div class="item-content item-input">
             <div class="item-inner">
-              <div class="item-title" data-localize="settings.appearance.dark">Dark Mode</div>
-              <div class="item-after">
-                <label class="toggle toggle-init">
-                  <input type="checkbox" id="dark-mode" field="appearance" name="dark-mode" />
-                  <span class="toggle-icon"></span>
-                </label>
+              <div class="item-title item-label" data-localize="settings.appearance.app-mode">App Mode</div>
+              <div class="item-input-wrap input-dropdown-wrap">
+                <select id="mode" name="mode" field="appearance">
+                  <option value="system" selected data-localize="settings.appearance.system">Use System Theme</option>
+                  <option value="light" data-localize="settings.appearance.light">Light</option>
+                  <option value="dark" data-localize="settings.appearance.dark">Dark</option>
+                </select>
               </div>
             </div>
           </div>

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -219,7 +219,10 @@
     "needs-restart": "Restart app to apply changes.",
     "appearance": {
       "title": "Appearance",
-      "dark": "Dark Mode",
+      "app-mode": "App Mode",
+      "system": "Use System Theme",
+      "light": "Light",
+      "dark": "Dark",
       "colour-theme": "Colour Theme",
       "animations": "Disable UI Animations",
       "start-page": "Start Page",

--- a/www/index.js
+++ b/www/index.js
@@ -438,7 +438,7 @@ document.addEventListener('deviceready', async function() {
     app.f7.views.main.router.navigate("/settings/");
   } else {
     settings = app.Settings.migrateSettings(settings);
-    app.Settings.changeTheme(settings.appearance["dark-mode"], settings.appearance.theme);
+    app.Settings.changeTheme(settings.appearance.mode, settings.appearance.theme);
     app.f7.views.main.router.navigate(settings.appearance["start-page"]);
   }
 

--- a/www/index.js
+++ b/www/index.js
@@ -422,6 +422,11 @@ document.addEventListener("page:reinit", function(event) {
 
 app.f7.on("init", async function(event) {});
 
+app.f7.on("darkThemeChange", function(isDark) {
+  let appMode = isDark ? "dark" : "light";
+  app.Settings.applyAppMode(appMode);
+});
+
 document.addEventListener("page:beforein", (e) => {
   app.localize();
 });


### PR DESCRIPTION
This closes #463. I even managed to implement the feature in a way that doesn't require an app restart.

To make the theme detection work, I had to add this plugin:
https://github.com/timbru31/cordova-plugin-android-dark-mode-support

The plugin is needed because the webview used by cordova-android apparently doesn't support the (prefers-color-scheme) media query by default. I don't really understand why. But anyway, it works with the plugin.

By the way @davidhealey are you serious about this "switching away from GitHub" stuff? I just saw that you edited the readme a few days ago. I haven't been following this whole controversy too actively, and I honestly don't understand what all the fuzz is about. After all, GitHub is offering their services completely free of charge, including unlimited repo hosting, CI/CD, and so much more. I feel like that's a pretty sweet deal. Maybe you can enlighten me :)