### PR TITLE
Improve Open Food Facts search results

### DIFF
--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -26,7 +26,7 @@ app.OpenFoodFacts = {
 
         // If query is a number, assume it's a barcode
         if (isNaN(query))
-          url = "https://world.openfoodfacts.org/cgi/search.pl?search_terms=" + encodeURIComponent(query) + "&search_simple=1&page_size=50&sort_by=last_modified_t&action=process&json=1";
+          url = "https://world.openfoodfacts.org/cgi/search.pl?search_terms=" + encodeURIComponent(query) + "&search_simple=1&page_size=50&sort_by=unique_scans_n&action=process&json=1";
         else
           url = "https://world.openfoodfacts.org/api/v0/product/" + encodeURIComponent(query) + ".json";
 


### PR DESCRIPTION
This changes the sort order for OFF search results to `unique_scans_n` (i.e. sorted by popularity) as discussed in #604. I did some tests and came to the conclusion that this sort order gives the most useful results.