### PR TITLE
Add Serbian language options in settings

### DIFF
--- a/www/activities/settings/views/appearance.html
+++ b/www/activities/settings/views/appearance.html
@@ -99,6 +99,8 @@
                   <option value="pl" data-localize="locale.polish">Polish</option>
                   <option value="pt" data-localize="locale.portuguese">Portuguese</option>
                   <option value="ru" data-localize="locale.russian">Russian</option>
+                  <option value="sr" data-localize="locale.serbian-cyrillic">Serbian (Cyrillic)</option>
+                  <option value="sr-CS" data-localize="locale.serbian-latin">Serbian (Latin)</option>
                   <option value="es" data-localize="locale.spanish">Spanish</option>
                   <option value="sv" data-localize="locale.swedish">Swedish</option>
                   <option value="tr" data-localize="locale.turkish">Turkish</option>

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -368,6 +368,8 @@
     "spanish": "Spanish",
     "dutch": "Dutch",
     "turkish": "Turkish",
-    "ukrainian": "Ukrainian"
+    "ukrainian": "Ukrainian",
+    "serbian-cyrillic": "Serbian (Cyrillic)",
+    "serbian-latin": "Serbian (Latin)"
   }
 }


### PR DESCRIPTION
This adds options for Serbian (Cyrillic) and Serbian (Latin) to the language dropdown in settings. However, note that this assumes that the Cyrillic variant uses the code `sr` and the Latin variant uses `sr-CS`, which is not the case at the moment.