### PR TITLE
Visualize tracking gaps in Statistic Chart

### DIFF
--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -355,6 +355,22 @@ app.Stats = {
         }
       }
 
+      // trim trailing and leading gaps
+      let valuesStartIndex = -1;
+      let valuesEndIndex = -1;
+      result.dataset.values.forEach((el, idx) => {
+        if (el) {
+          if (valuesStartIndex < 0) {
+            valuesStartIndex = idx;
+          }
+          valuesEndIndex = idx;
+        }
+      });
+      if (valuesStartIndex > 0 || valuesEndIndex < result.dataset.values.length-1) {
+        result.dataset.values = result.dataset.values.slice(valuesStartIndex, valuesEndIndex+1);
+        result.dates = result.dates.slice(valuesStartIndex, valuesEndIndex+1);
+      }
+
       let title = app.strings.nutriments[field] || app.strings.statistics[field] || field;
       let goal = app.Goals.getAverageGoal(field);
 

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -517,5 +517,14 @@ app.Utils = {
       reader.onloadend = () => resolve(reader.result);
       reader.readAsDataURL(blob);
     });
+  },
+
+  dateToLocaleDateString: function(date) {
+    return date.toLocaleDateString([], {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      timeZone: "UTC"
+    });
   }
 };


### PR DESCRIPTION
Implements #637 

#### Changes
- retain diary data without values
- check and fill in missing days between diary entries
- enable _spanGaps_ option for line chart -- line chart renders an interpolated view; bars show gaps prominently