### PR TITLE
Improve diary pie chart

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -160,6 +160,7 @@ app.DiaryChart = {
         labels: data.labels
       },
       options: {
+        events: [],
         tooltips: {
           enabled: false
         },


### PR DESCRIPTION
This disables the various click and hower events for the diary pie chart on the overview page. It is now no longer possible to hide individual slices from the diagram (see #640). And if you tap on a slice, its color no longer changes to a darker tone.