### PR TITLE
Hide number of servings field for recipes

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -555,6 +555,8 @@ app.Diary = {
         ["serving-size", "number-of-servings"].forEach((field) => {
           let li = document.createElement("li");
           li.className = "item-content item-input";
+          if (field == "number-of-servings" && item.type == "recipe")
+            li.style.display = "none"; // number of servings field not needed for recipes
           ul.appendChild(li);
 
           let inner = document.createElement("div");

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -432,10 +432,15 @@ app.FoodEditor = {
     }
 
     // Quantity (number of servings)
-    if (item.quantity != undefined)
-      app.FoodEditor.el.quantity.value = parseFloat(item.quantity);
-    else
+    if (item.type == "recipe") {
+      // number of servings field not needed for recipes
+      app.FoodEditor.el.quantityContainer.style.display = "none";
       app.FoodEditor.el.quantity.value = 1;
+    } else if (item.quantity != undefined) {
+      app.FoodEditor.el.quantity.value = parseFloat(item.quantity);
+    } else {
+      app.FoodEditor.el.quantity.value = 1;
+    }
     app.FoodEditor.el.quantity.oldValue = app.FoodEditor.el.quantity.value;
   },
 


### PR DESCRIPTION
This closes #642. The "Number of Servings" field in the diary is now hidden for recipes. This should clear up the confusion about the issue.

Adding a recipe to the diary via the quantity prompt:
Before...
![localhost_](https://user-images.githubusercontent.com/19289477/194707036-d51b426f-4776-4d58-8d79-58804aade7cf.png)

After...
![localhost_ (1)](https://user-images.githubusercontent.com/19289477/194707041-ac07bb4e-8775-411a-9551-87802bad5f78.png)


Viewing/Editing the diary entry of a recipe:
Before...
![localhost_ (2)](https://user-images.githubusercontent.com/19289477/194707045-ba50a5c2-1ab4-47a1-b544-51215f5ef86e.png)

After...
![localhost_ (3)](https://user-images.githubusercontent.com/19289477/194707048-f8cd9d40-65d2-4677-bb32-bf4cf2e7e1d0.png)
