### PR TITLE
Improve handling of recipe serving and quantity

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -33,12 +33,6 @@ There are two parameters you can use the specify the quantity of an item: the `s
 - The `serving size` must be specified in the unit which the nutrition information is based on. For example, if the nutrition information is per 100g, but your serving was only 60g, then enter `60`.
 - The `number of servings` functions as a multiplication factor. For example, if you ate two and a halve servings of the food, enter `2.5`.
 
-When you add a recipe to the Diary, you can only enter a serving size and no number of servings. Below are some examples for how to use this field for different types of recipes:
-
-- If the recipe unit is `cookies` and the recipe serving size is `20` (i.e. the recipe makes 20 cookies), enter the number of cookies you ate.
-- If the recipe unit is `servings` and the recipe serving size is `4` (i.e. the recipe makes 4 servings), enter the number of servings you ate.
-- If the recipe unit is `cake` and the recipe serving size is `1` (i.e. the recipe makes 1 cake), enter the share of the cake you ate, e.g. `0.333`.
-
 ## Specifying the quantities of diary entries requires too much switching back and forth. Isn't there a more convenient way?
 
 Check out the `Prompt for quantity when adding items` option under `Settings > Diary`.

--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -570,8 +570,6 @@ app.Diary = {
         ["serving-size", "number-of-servings"].forEach((field) => {
           let li = document.createElement("li");
           li.className = "item-content item-input";
-          if (field == "number-of-servings" && item.type == "recipe")
-            li.style.display = "none"; // number of servings field not needed for recipes
           ul.appendChild(li);
 
           let inner = document.createElement("div");

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -432,11 +432,7 @@ app.FoodEditor = {
     }
 
     // Quantity (number of servings)
-    if (item.type == "recipe") {
-      // number of servings field not needed for recipes
-      app.FoodEditor.el.quantityContainer.style.display = "none";
-      app.FoodEditor.el.quantity.value = 1;
-    } else if (item.quantity != undefined) {
+    if (item.quantity != undefined) {
       app.FoodEditor.el.quantity.value = parseFloat(item.quantity);
     } else {
       app.FoodEditor.el.quantity.value = 1;

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -72,7 +72,7 @@
               <li class="item-content item-input inline-labels">
                 <div class="item-inner">
                   <div class="item-title item-label">
-                    <label for="portion" data-localize="food-editor.serving-size">Serving Size</label>
+                    <label for="portion" data-localize="food-editor.recipe-size">Recipe Amount</label>
                   </div>
                   <div class="item-input-wrap">
                     <input class="align-end auto-select" type="number" min="0" step="any" id="portion" name="portion" required validate>
@@ -83,7 +83,7 @@
               <li class="item-content item-input inline-labels">
                 <div class="item-inner">
                   <div class="item-title item-label">
-                    <label for="unit" data-localize="food-editor.serving-unit">Serving Unit</label>
+                    <label for="unit" data-localize="food-editor.recipe-unit">Recipe Unit</label>
                   </div>
                   <div class="item-input-wrap">
                     <input class="align-end auto-select" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" id="unit" name="unit" required validate>

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -178,6 +178,8 @@
     "category": "Category",
     "serving-size": "Serving Size",
     "serving-unit": "Serving Unit",
+    "recipe-size": "Recipe Amount",
+    "recipe-unit": "Recipe Unit",
     "number-of-servings": "Number of Servings",
     "notes": "Notes",
     "nutrition": "Nutrition",


### PR DESCRIPTION
This reverts the change made in #645, so it is now again possible to enter the number of servings for recipes. I think it makes more sense to allow this, after all. To clear up the confusion, I have now changed some of the form input labels in the recipe editor. I also updated the user guide to reflect these changes.