### PR TITLE
Default to system theme

### DIFF
--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -629,7 +629,7 @@ app.Settings = {
         usda: false
       },
       appearance: {
-        mode: "light",
+        mode: "system",
         theme: "color-theme-red",
         animations: false,
         locale: "auto",


### PR DESCRIPTION
On first install the application should default to the user's preference, only overriding it on configuration.