### PR TITLE
Change 'nutriments' to 'nutrients' in strings file and UI defaults

### DIFF
--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -104,7 +104,7 @@
             <ul id="nutrition">
             </ul>
             <ul>
-              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutriments</a></li>
+              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutrients</a></li>
             </ul>
           </div>
         </li>

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -135,7 +135,7 @@
             <ul id="nutrition">
             </ul>
             <ul>
-              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutriments</a></li>
+              <li><a class="list-button" id="nutrition-button" data-localize="foods-meals-recipes.show-more-nutriments">Show more nutrients</a></li>
             </ul>
           </div>
         </li>

--- a/www/activities/settings/views/diary.html
+++ b/www/activities/settings/views/diary.html
@@ -84,7 +84,7 @@
         <li>
           <div class="item-content">
             <div class="item-inner">
-              <div class="item-title" data-localize="settings.diary.show-all-nutriments">Show all nutriments on Overview page</div>
+              <div class="item-title" data-localize="settings.diary.show-all-nutriments">Show all nutrients on Overview page</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
                   <input type="checkbox" field="diary" name="show-all-nutriments" />

--- a/www/activities/settings/views/nutriments.html
+++ b/www/activities/settings/views/nutriments.html
@@ -25,7 +25,7 @@
       <div class="left">
         <a class="link back"><i class="icon icon-back"></i></a>
       </div>
-      <div class="title" data-localize="settings.nutriments.title">Nutriments</div>
+      <div class="title" data-localize="settings.nutriments.title">Nutrients</div>
       <div class="right"></div>
     </div>
   </div>

--- a/www/activities/settings/views/settings.html
+++ b/www/activities/settings/views/settings.html
@@ -73,7 +73,7 @@
 
         <li>
           <a href="./nutriments/" class="item-link item-content">
-            <div class="item-inner" data-localize="settings.nutriments.title">Nutriments</div>
+            <div class="item-inner" data-localize="settings.nutriments.title">Nutrients</div>
           </a>
         </li>
 

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -164,8 +164,8 @@
     "selected": "Selected",
     "search": "Search",
     "scan-prompt": "Place a barcode inside the scan area",
-    "show-more-nutriments": "Show more nutriments",
-    "show-less-nutriments": "Show less nutriments",
+    "show-more-nutriments": "Show more nutrients",
+    "show-less-nutriments": "Show fewer nutrients",
     "added-to-selection": "Scanned item added to selection"
   },
   "food-editor": {
@@ -253,12 +253,12 @@
       "timestamps": "Show Timestamps",
       "thumbnails": "Show Thumbnails",
       "wifi-thumbnails": "Only show thumbnails over Wi-Fi",
-      "show-all-nutriments": "Show all nutriments on Overview page",
+      "show-all-nutriments": "Show all nutrients on Overview page",
       "show-units": "Show nutrition units",
       "prompt-add-items": "Prompt for quantity when adding items"
     },
     "nutriments": {
-      "title": "Nutriments",
+      "title": "Nutrients",
       "field": "Name",
       "unit": "Unit",
       "add": "Add Field",


### PR DESCRIPTION
I changed only the default and not the symbol names or strings file. Looking for feedback on whether that ought to be done to avoid confusion.

"Nutrients" is a far more common term referring to the various nutritional components of food. Nutriments is most often used to refer to the food itself (as in [this company](https://www.nutriment.co.uk/)), or in particular to the "four nutriments" in Buddhism which refer to contexts in which food is eaten. [Reference](https://plumvillage.org/library/sutras/discourse-on-the-four-kinds-of-nutriments).