### PR TITLE
Include Alcohol as Energy Nutriment

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -25,7 +25,8 @@ app.DiaryChart = {
     'rgba(213, 11, 11, 0.5)',
     'rgba(8, 118, 184, 0.5)',
     'rgba(0, 151, 225, 0.5)',
-    'rgba(255, 206, 86, 0.5)'
+    'rgba(255, 206, 86, 0.5)',
+    'rgba(111, 208, 140,0.5)'
   ],
   chartType: "pie",
   dbData: undefined,

--- a/www/activities/goals/js/goals.js
+++ b/www/activities/goals/js/goals.js
@@ -302,6 +302,9 @@ app.Goals = {
     // Each gram of fat and saturated-fat has 9 calories
     if (nutriment == "fat" || nutriment == "saturated-fat")
       return 9;
+    // Each gram of alcohol has 7 calories
+    if (nutriment == "alcohol")
+    return 7;
   },
 
   getDiaryEntryFromDB: function(date) {

--- a/www/index.js
+++ b/www/index.js
@@ -31,7 +31,7 @@ const app = {
     "hips": "cm",
     "body fat": "%"
   },
-  energyMacroNutriments: ["fat", "saturated-fat", "carbohydrates", "sugars", "proteins"],
+  energyMacroNutriments: ["fat", "saturated-fat", "carbohydrates", "sugars", "proteins", "alcohol"],
   nutriments: ["kilojoules", "calories", "fat", "saturated-fat", "carbohydrates", "sugars", "fiber", "proteins", "salt", "sodium", "cholesterol", "trans-fat", "monounsaturated-fat", "polyunsaturated-fat", "omega-3-fat", "omega-6-fat", "omega-9-fat", "vitamin-a", "vitamin-b1", "vitamin-b2", "vitamin-pp", "pantothenic-acid", "vitamin-b6", "biotin", "vitamin-b9", "vitamin-b12", "vitamin-c", "vitamin-d", "vitamin-e", "vitamin-k", "potassium", "chloride", "calcium", "phosphorus", "iron", "magnesium", "zinc", "copper", "manganese", "fluoride", "selenium", "iodine", "caffeine", "alcohol", "sucrose", "glucose", "fructose", "lactose"],
   nutrimentUnits: {
     "kilojoules": "kJ",


### PR DESCRIPTION
Fixed chart and percentages when there is logged alcohol. Added alcohol as a energy macro nutrient. Added calories per gram of alcohol. Previously Macro percentages could be significantly off from correct percentages. Alcohol only shows up in the Overview if someone has logged item with alcohol.  