### PR TITLE
Fix camera and storage on Android 13+

### DIFF
--- a/metadata/en-US/changelogs/30601.txt
+++ b/metadata/en-US/changelogs/30601.txt
@@ -1,7 +1,0 @@
-- added language options for Czech and Romanian
-- added new splashscreen and app icon, including monochrome support
-- the statistics page now remembers both the selected stat and range
-- various bugfixes
-
-You can find the full changelog at 
-https://github.com/davidhealey/waistline/releases

--- a/metadata/en-US/changelogs/30701.txt
+++ b/metadata/en-US/changelogs/30701.txt
@@ -1,0 +1,4 @@
+- re-release due to problem with f-droid
+
+You can find the full changelog at 
+https://github.com/davidhealey/waistline/releases

--- a/metadata/en-US/changelogs/30702.txt
+++ b/metadata/en-US/changelogs/30702.txt
@@ -1,0 +1,5 @@
+- added alcohol as macro nutrient to the diary pie chart
+- fixed camera and backup not working on Android 13
+
+You can find the full changelog at 
+https://github.com/davidhealey/waistline/releases

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cordova-electron": "^3.1.0",
     "cordova-plugin-android-dark-mode-support": "^1.0.0",
     "cordova-plugin-browsersync-gen2": "^1.1.7",
-    "cordova-plugin-camera": "^6.0.0",
+    "cordova-plugin-camera": "github:felicienfrancois/cordova-plugin-camera",
     "cordova-plugin-chooser": "^1.3.2",
     "cordova-plugin-crop": "github:rastafan/cordova-plugin-crop",
     "cordova-plugin-device": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cordova-plugin-chooser": "^1.3.2",
     "cordova-plugin-crop": "github:rastafan/cordova-plugin-crop",
     "cordova-plugin-device": "^2.0.3",
-    "cordova-plugin-file": "^6.0.2",
+    "cordova-plugin-file": "^8.0.0",
     "cordova-plugin-inappbrowser": "^5.0.0",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-network-information": "^3.0.0",

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -328,28 +328,9 @@ app.Utils = {
           baseDir.getDirectory("Documents", { create: true }, function (documentsDir) {
             documentsDir.getDirectory("Waistline", { create: true }, function (waistlineDir) {
               waistlineDir.getDirectory(dirname, { create: true }, function (backupDir) {
-                backupDir.getFile(filename, { create: true }, (file) => {
-
-                  // Write to the file, overwriting existing content
-                  file.createWriter((fileWriter) => {
-                    let blob = new Blob([data], {
-                      type: "text/plain"
-                    });
-
-                    fileWriter.write(blob);
-
-                    fileWriter.onwriteend = () => {
-                      console.log("Successul file write");
-                      resolve(file.fullPath);
-                    };
-
-                    fileWriter.onerror = (e) => {
-                      console.warn("Failed to write file", e);
-                      resolve();
-                    };
-                  });
-
-                }, (e) => {
+                app.Utils.writeFileInBackupDir(backupDir, filename, data).then((fullPath) => {
+                  resolve(fullPath);
+                }).catch(() => {
                   resolve();
                 });
               }, (e) => {
@@ -368,6 +349,36 @@ app.Utils = {
         console.warn("Write to file doesn't work in browser");
         resolve();
       }
+    });
+  },
+
+  writeFileInBackupDir: function(backupDir, filename, data) {
+    return new Promise(function(resolve, reject) {
+      backupDir.getFile(filename, { create: true }, (file) => {
+
+        // Write to the file, overwriting existing content
+        file.createWriter((fileWriter) => {
+          let blob = new Blob([data], {
+            type: "text/plain"
+          });
+
+          fileWriter.write(blob);
+
+          fileWriter.onwriteend = () => {
+            console.log("Successul file write");
+            resolve(file.fullPath);
+          };
+
+          fileWriter.onerror = (e) => {
+            console.error("Failed to write file", e);
+            reject();
+          };
+        });
+
+      }, (e) => {
+        console.error("Error resolving file", e);
+        reject();
+      });
     });
   },
 

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -371,66 +371,6 @@ app.Utils = {
     });
   },
 
-  readFile: function(filename) {
-    return new Promise(function(resolve, reject) {
-      if (app.mode !== "development" && device.platform !== "browser") {
-
-        let base = cordova.file.externalRootDirectory;
-        let dirname = app.Utils.getBackupDirectoryName();
-        let path = base + `Documents/Waistline/${dirname}/${filename}`;
-
-        console.log("Reading file: " + path);
-
-        window.resolveLocalFileSystemURL(base, (baseDir) => {
-          baseDir.getDirectory("Documents", { create: true }, function (documentsDir) {
-            documentsDir.getDirectory("Waistline", { create: true }, function (waistlineDir) {
-              waistlineDir.getDirectory(dirname, { create: true }, function (backupDir) {
-                backupDir.getFile(filename, {}, (file) => {
-
-                  file.file((file) => {
-                    let fileReader = new FileReader();
-
-                    fileReader.readAsText(file);
-
-                    fileReader.onloadend = (e) => {
-                      console.log("Successful file read", e);
-                      resolve(e.target.result);
-                    };
-
-                    fileReader.onerror = (e) => {
-                      console.warn("Failed to read file", e);
-                      resolve();
-                    };
-                  });
-
-                }, (e) => {
-                  console.warn("Failed to access file", e);
-                  switch (e.code) {
-                    case 1:
-                      alert("File not found: " + path);
-                      break;
-                  }
-                  resolve();
-                });
-              }, (e) => {
-                resolve();
-              });
-            }, (e) => {
-              resolve();
-            });
-          }, (e) => {
-            resolve();
-          });
-        }, (e) => {
-          resolve();
-        });
-      } else {
-        console.warn("Read file doesn't work in browser");
-        resolve();
-      }
-    });
-  },
-
   checkIfFileExists: function(path) {
     window.resolveLocalFileSystemURL(path, () => {
       return true;


### PR DESCRIPTION
This fixes the permission issues with Android 13/SDK 33 and closes #733.

I replaced the official `cordova-plugin-camera` with the fork from [felicienfrancois/cordova-plugin-camera](https://github.com/felicienfrancois/cordova-plugin-camera). This one is compatible with Android 13. Once the official plugin is fixed, we can switch back to that one.

I also updated the files plugin and changed the logic for the backup. If the user is on Android 13 or above, the backup files are now put in: `Android/data/com.waist.line/files`

On older versions of Android, it continues to use the backup location in the Documents folder: `Documents/Waistline/1667758046`

For users on Android 13 or above, this has the disadvantage that the backup files will be deleted when the app is uninstalled. But I don't see any way to prevent this. It looks like apps are no longer allowed to write to the Documents folder on Android 13 ☹️ 

Note that because of the changed plugins, you need to install the new versions before you build. The safest way to do that seems to be to delete the `platforms` and `plugins` folders, do `npm install`, and then re-add all the platforms with `cordova platform add <platform-name>`. I don't know why this stuff always has to be complicated 😅 