### PR TITLE
Fix barcode link clicks being unreliable

### DIFF
--- a/metadata/en-US/changelogs/30703.txt
+++ b/metadata/en-US/changelogs/30703.txt
@@ -1,4 +1,5 @@
 - fixed option to follow the system theme
+- various bugfixes
 
 You can find the full changelog at 
 https://github.com/davidhealey/waistline/releases

--- a/metadata/en-US/changelogs/30800.txt
+++ b/metadata/en-US/changelogs/30800.txt
@@ -1,4 +1,5 @@
 - fixed option to follow the system theme
+- various bugfixes
 
 You can find the full changelog at 
 https://github.com/davidhealey/waistline/releases

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -406,20 +406,17 @@ app.FoodEditor = {
       app.FoodEditor.el.barcodeContainer.style.display = "block";
       app.FoodEditor.el.barcode.value = code;
 
-      if (navigator.connection.type !== "none") {
-        let url;
-        if (item.barcode.startsWith("fdcId_"))
-          url = "https://fdc.nal.usda.gov/fdc-app.html#/food-details/" + code + "/nutrients";
-        else
-          url = "https://world.openfoodfacts.org/product/" + code;
+      let url;
+      if (item.barcode.startsWith("fdcId_"))
+        url = "https://fdc.nal.usda.gov/fdc-app.html#/food-details/" + code + "/nutrients";
+      else
+        url = "https://world.openfoodfacts.org/product/" + code;
 
-        if (!app.FoodEditor.el.barcode.hasClickEvent) {
-          app.FoodEditor.el.barcode.parentElement.addEventListener("click", (e) => {
-            cordova.InAppBrowser.open(url, '_system');
-            return false;
-          });
-          app.FoodEditor.el.barcode.hasClickEvent = true;
-        }
+      if (!app.FoodEditor.el.barcode.hasClickEvent) {
+        app.FoodEditor.el.barcode.parentElement.addEventListener("click", (e) => {
+          cordova.InAppBrowser.open(url, '_system');
+        });
+        app.FoodEditor.el.barcode.hasClickEvent = true;
       }
     }
 

--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -36,6 +36,8 @@ i.searchbar-icon {margin: -12px 12px;}
 
 .photo-holder {width: 100%; text-align: center;}
 
+#food-edit-form #barcode {pointer-events: none;}
+
 #food-edit-form .radio-label {vertical-align: middle;}
 
 #food-edit-form .form-inputs .item-input .item-title {width: 32vw;}


### PR DESCRIPTION
I have no idea why this suddenly became an issue, but clicking on the barcode in the food editor (to open the corresponding OFF/USDA entry) is very unreliable in the latest build. I fixed it by styling the barcode field with `pointer-events: none`.