### PR TITLE
Use kilojoule value if no calorie value is entered

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -291,7 +291,7 @@ app.FoodEditor = {
     const energyUnit = app.Settings.get("units", "energy");
 
     if (item !== undefined && item.nutrition.kilojoules == undefined && energyUnit == units.kilojoules)
-      item.nutrition.kilojoules = app.Utils.convertUnit(item.nutrition.calories, units.calories, units.kilojoules);
+      item.nutrition.kilojoules = app.Utils.convertUnit(item.nutrition.calories, units.calories, units.kilojoules, 1);
 
     let ul = app.FoodEditor.el.nutrition;
     ul.innerHTML = "";
@@ -663,8 +663,12 @@ app.FoodEditor = {
         item.nutrition = {};
 
         // Always store a calorie value
-        if (energyUnit == units.kilojoules && kilojoulesEl.value)
-          caloriesEl.value = app.Utils.convertUnit(kilojoulesEl.value, units.kilojoules, units.calories);
+        if (!caloriesEl.value || energyUnit == units.kilojoules) {
+          if (kilojoulesEl.value)
+            caloriesEl.value = app.Utils.convertUnit(kilojoulesEl.value, units.kilojoules, units.calories, 1);
+          else
+            caloriesEl.value = "";
+        }
 
         for (let i = 0; i < inputs.length; i++) {
           let x = inputs[i];


### PR DESCRIPTION
This solves the kcal/kJ conversion issue raised in #757. The app can now intelligently make the necessary conversions without the need to change the preferred energy unit.

If the preferred energy unit is set to calories, the new behavior is as follows:
- user enters both a calorie value and a kilojoule value -> they both get stored
- user enters only a calorie value and no kilojoule value -> calorie value gets stored, kilojoule value stays empty
- user enters only a kilojoule value and no calorie value -> kilojoule value gets stored, **calorie value is automatically calculated from kilojoules and also stored**

If the preferred energy unit is set to kilojoules, the behavior is simpler and only depends on the entered kilojoule value. This is because the app internally needs calories for calculations:
- user enters a kilojoule value -> kilojoule value is stored, calorie value is automatically calculated from kilojoules and also stored
- user does not enter a kilojoule value -> kilojoule and calorie values both stay empty