### PR TITLE
Improve About page and add link to User Guide

### DIFF
--- a/www/activities/about/views/about.html
+++ b/www/activities/about/views/about.html
@@ -38,11 +38,19 @@
       <p data-localize="about.p1">Waistline was built using Cordova available under the Apache license. Also included are Framework7, jQuery, jQuery localize, and ChartJS which are under the MIT license. The HTML, CSS, and other javascript that make
         up the main body of the app are under the GPLv3 license.</p>
       <p>
-        <span data-localize="about.p2">The source code for Waistline can be found at</span>
-        <a class="link" href="https://github.com/davidhealey/waistline" onclick="cordova.InAppBrowser.open('https://github.com/davidhealey/waistline', '_system'); return false;">github.com/davidhealey/waistline</a>.
+        <a class="link" href="https://github.com/davidhealey/waistline" onclick="cordova.InAppBrowser.open('https://github.com/davidhealey/waistline', '_system'); return false;">
+          <i class="icon material-icons">code</i>
+          <span data-localize="about.source-code">Source Code</span>
+        </a>
       </p>
       <p>
-        <span data-localize="about.p3">Current version:</span>
+        <a class="link" href="https://github.com/davidhealey/waistline/blob/master/FAQ.md" onclick="cordova.InAppBrowser.open('https://github.com/davidhealey/waistline/blob/master/FAQ.md', '_system'); return false;">
+          <i class="icon material-icons">help_outline</i>
+          <span data-localize="about.user-guide">User Guide / FAQ</span>
+        </a>
+      </p>
+      <p>
+        <span data-localize="about.version">Current version:</span>
         <span>%%VERSION%%</span>
       </p>
     </div>

--- a/www/assets/locales/locale-de.json
+++ b/www/assets/locales/locale-de.json
@@ -375,8 +375,9 @@
     "title": "Über",
     "p0": "Waistline wurde von David Healey entwickelt und von verschiedenen GitHub-Nutzern durch Vorschläge und Anpassungen unterstützt.",
     "p1": "Waistline wurde mit dem Cordova Framework und OnsenUI erstellt, was unter der Apache Lizenz verfügbar ist. Ebenfalls verwendet wurden jQuery, jQuery localize und ChartJS, welche unter der MIT Lizenz stehen. HTML, CSS und JavaScript, die das Hauptgerüst der App bilden, gehören zur GPLv3 Lizenz.",
-    "p2": "Den Quellcode von Waistline findest du unter",
-    "p3": "Aktuelle Version:"
+    "source-code": "Quellcode",
+    "user-guide": "Anleitung / FAQ",
+    "version": "Aktuelle Version:"
   },
   "locale": {
     "auto": "Automatisch erkennen",

--- a/www/assets/locales/locale-de.json
+++ b/www/assets/locales/locale-de.json
@@ -375,9 +375,8 @@
     "title": "Über",
     "p0": "Waistline wurde von David Healey entwickelt und von verschiedenen GitHub-Nutzern durch Vorschläge und Anpassungen unterstützt.",
     "p1": "Waistline wurde mit dem Cordova Framework und OnsenUI erstellt, was unter der Apache Lizenz verfügbar ist. Ebenfalls verwendet wurden jQuery, jQuery localize und ChartJS, welche unter der MIT Lizenz stehen. HTML, CSS und JavaScript, die das Hauptgerüst der App bilden, gehören zur GPLv3 Lizenz.",
-    "source-code": "Quellcode",
-    "user-guide": "Anleitung / FAQ",
-    "version": "Aktuelle Version:"
+    "p2": "Den Quellcode von Waistline findest du unter",
+    "p3": "Aktuelle Version:"
   },
   "locale": {
     "auto": "Automatisch erkennen",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -376,8 +376,9 @@
     "title": "About",
     "p0": "Waistline was created by David Healey with suggestions and contributions from users.",
     "p1": "Waistline was built using Cordova available under the Apache license. Also included are Framework7, jQuery, jQuery localize, and ChartJS which are under the MIT license. The HTML, CSS, and other javascript that make up the main body of the app are under the GPLv3 license.",
-    "p2": "The source code for Waistline can be found at",
-    "p3": "Current version:"
+    "source-code": "Source Code",
+    "user-guide": "User Guide / FAQ",
+    "version": "Current version:"
   },
   "locale": {
     "auto": "Detect Automatically",


### PR DESCRIPTION
This adds a link to the [user guide](https://github.com/davidhealey/waistline/blob/master/FAQ.md) on the About page within the app to make it easier to discover.