### PR TITLE
Improve filter for items with no category

### DIFF
--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -324,7 +324,7 @@ app.Foodlist = {
         app.Foodlist.renderList(true);
       }
     });
-    app.FoodsMealsRecipes.populateCategoriesField(app.Foodlist.el.searchFilter, undefined, true, true, false, {
+    app.FoodsMealsRecipes.populateCategoriesField(app.Foodlist.el.searchFilter, undefined, true, true, true, false, {
       beforeOpen: (smartSelect, prevent) => {
         smartSelect.selectEl.selectedIndex = -1;
       },

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -62,7 +62,7 @@ app.FoodEditor = {
     this.setLinkButtonIcon();
 
     const categoriesEditable = (app.FoodEditor.origin == "foodlist");
-    app.FoodsMealsRecipes.populateCategoriesField(app.FoodEditor.el.categories, app.FoodEditor.item, false, categoriesEditable, true);
+    app.FoodsMealsRecipes.populateCategoriesField(app.FoodEditor.el.categories, app.FoodEditor.item, false, false, categoriesEditable, true);
 
     if (app.FoodEditor.item) {
       this.populateFields(app.FoodEditor.item);

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -704,7 +704,7 @@ app.FoodsMealsRecipes = {
     let labels = app.Settings.get("foodlist", "labels") || [];
     let categories = app.Settings.get("foodlist", "categories") || {};
 
-    if (appendNoCategory) {
+    if (appendNoCategory && labels.length > 0) {
       labels.push(app.FoodsCategories.noCategoryLabel);
     }
 

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -292,7 +292,7 @@ app.FoodsMealsRecipes = {
           if (item.categories) {
             if (!item.categories.includes(category))
               return false;
-          } else if (noCategoryFilter === -1) {
+          } else if (noCategoryFilter === -1 || categoriesFilter.length >= 2) {
             return false;
           }
         }

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -292,10 +292,7 @@ app.FoodsMealsRecipes = {
           if (item.categories) {
             if (!item.categories.includes(category))
               return false;
-          } else if (noCategoryFilter !== -1 && !item.categories) {
-            return true;
-          }
-          else {
+          } else if (noCategoryFilter === -1) {
             return false;
           }
         }

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -700,12 +700,15 @@ app.FoodsMealsRecipes = {
     });
   },
 
-  populateCategoriesField: function(element, item, appendArchivedAndEmptyCategory, enablePicker, enableRipple, pickerEventHandlers) {
+  populateCategoriesField: function(element, item, appendNoCategory, appendArchived, enablePicker, enableRipple, pickerEventHandlers) {
     let labels = app.Settings.get("foodlist", "labels") || [];
     let categories = app.Settings.get("foodlist", "categories") || {};
 
-    if (appendArchivedAndEmptyCategory) {
+    if (appendNoCategory) {
       labels.push(app.FoodsCategories.noCategoryLabel);
+    }
+
+    if (appendArchived) {
       labels.push(app.FoodsCategories.archivedLabel);
     }
 

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -705,10 +705,9 @@ app.FoodsMealsRecipes = {
     let categories = app.Settings.get("foodlist", "categories") || {};
 
     if (appendArchivedAndEmptyCategory) {
-      labels.push(app.FoodsCategories.archivedLabel);
       labels.push(app.FoodsCategories.noCategoryLabel);
+      labels.push(app.FoodsCategories.archivedLabel);
     }
-
 
     if (enablePicker) {
       let select = document.createElement("select");

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -34,7 +34,7 @@ app.MealEditor = {
         app.MealEditor.populateInputs(context.meal);
       }
 
-      app.FoodsMealsRecipes.populateCategoriesField(app.MealEditor.el.categories, app.MealEditor.meal, false, true, true);
+      app.FoodsMealsRecipes.populateCategoriesField(app.MealEditor.el.categories, app.MealEditor.meal, false, false, true, true);
 
       // From food list
       if (context.items)

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -260,7 +260,7 @@ app.Meals = {
         app.Meals.renderList(true);
       }
     });
-    app.FoodsMealsRecipes.populateCategoriesField(app.Meals.el.searchFilter, undefined, false, true, false, {
+    app.FoodsMealsRecipes.populateCategoriesField(app.Meals.el.searchFilter, undefined, true, false, true, false, {
       beforeOpen: (smartSelect, prevent) => {
         smartSelect.selectEl.selectedIndex = -1;
       },

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -34,7 +34,7 @@ app.RecipeEditor = {
         app.RecipeEditor.populateInputs(context.recipe);
       }
 
-      app.FoodsMealsRecipes.populateCategoriesField(app.RecipeEditor.el.categories, app.RecipeEditor.recipe, false, true, true);
+      app.FoodsMealsRecipes.populateCategoriesField(app.RecipeEditor.el.categories, app.RecipeEditor.recipe, false, false, true, true);
 
       // From food list
       if (context.items)

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -221,7 +221,7 @@ app.Recipes = {
         app.Recipes.renderList(true);
       }
     });
-    app.FoodsMealsRecipes.populateCategoriesField(app.Recipes.el.searchFilter, undefined, true, true, false, {
+    app.FoodsMealsRecipes.populateCategoriesField(app.Recipes.el.searchFilter, undefined, true, true, true, false, {
       beforeOpen: (smartSelect, prevent) => {
         smartSelect.selectEl.selectedIndex = -1;
       },

--- a/www/activities/settings/js/foods-categories.js
+++ b/www/activities/settings/js/foods-categories.js
@@ -23,7 +23,7 @@ app.FoodsCategories = {
   defaultLabels: ["🌳", "🏪"],
   defaultCategories: {"🌳": "", "🏪": ""},
   archivedLabel: "🗑️",
-  noCategoryLabel: "⚠",
+  noCategoryLabel: "⚠️",
 
   populateFoodCategoriesList: function() {
     let labels = app.Settings.get("foodlist", "labels") || [];

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -166,7 +166,7 @@ app.Settings = {
       importFoods.addEventListener("click", function(e) {
         app.Settings.importFoods();
       });
-      app.FoodsMealsRecipes.populateCategoriesField(document.getElementById("categories"), {}, false, true, true);
+      app.FoodsMealsRecipes.populateCategoriesField(document.getElementById("categories"), {}, false, false, true, true);
     }
 
     let exportDiary = document.getElementById("export-diary");


### PR DESCRIPTION
Thanks @ayecptn for your contribution. This PR contains some minor improvements, including:

- Replaced the `\u26A0` ⚠ icon with the full color emoji version `\u26A0\uFE0F` to make sure it renders correctly.
- Refactored the filter logic to make the code a bit easier to read.
- Swapped the order of the archived category and the empty category because I think it makes more sense this way.

Edit: I just pushed three more improvements

- Ensure that no items are shown when the user selects both the "empty" category and another category (since this combination is impossible).
- Make the "empty" category independent from the "archived" category. This allows us to also show it on the meals tab (where the "archived" category is not shown since meals can't be archived).
- Only show the "empty" category option if there actually exist other categories.