### PR TITLE
Add ability to take photos for meals and recipes

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -474,6 +474,7 @@ app.FoodEditor = {
     if (item.image_url !== undefined && item.image_url !== "" && item.image_url !== "undefined") {
 
       if (app.Settings.get("foodlist", "show-images")) {
+        let removable = (app.FoodEditor.origin == "foodlist");
 
         if (item.image_url.startsWith("http")) {
           let wifiOnly = app.Settings.get("foodlist", "wifi-images");
@@ -482,11 +483,10 @@ app.FoodEditor = {
           if (navigator.connection.type !== "none") {
             if ((wifiOnly && navigator.connection.type == "wifi") || !wifiOnly) {
               let src = unescape(item.image_url);
-              app.FoodEditor.insertImageEl(0, src, false);
+              app.FoodEditor.insertImageEl(0, src, removable);
             }
           }
         } else {
-          let removable = (app.FoodEditor.origin == "foodlist");
           app.FoodEditor.insertImageEl(0, item.image_url, removable);
         }
       }

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -66,7 +66,7 @@ app.FoodEditor = {
 
     if (app.FoodEditor.item) {
       this.populateFields(app.FoodEditor.item);
-      this.populateImage(app.FoodEditor.item);
+      this.populateMainImage(app.FoodEditor.item);
     }
 
     if (app.FoodEditor.item && app.FoodEditor.item.category !== undefined)
@@ -100,10 +100,10 @@ app.FoodEditor = {
     app.FoodEditor.el.ttsIcon = document.querySelector(".page[data-name='food-editor'] #tts-icon");
     app.FoodEditor.el.nutritionButton = document.querySelector(".page[data-name='food-editor'] #nutrition-button");
     app.FoodEditor.el.mainPhoto = document.querySelector(".page[data-name='food-editor'] #main-photo");
-    app.FoodEditor.el.addPhoto = Array.from(document.getElementsByClassName("add-photo"));
-    app.FoodEditor.el.addPhotoCamera = Array.from(document.getElementsByClassName("add-photo-camera"));
-    app.FoodEditor.el.addPhotoLibrary = Array.from(document.getElementsByClassName("add-photo-library"));
-    app.FoodEditor.el.photoHolder = Array.from(document.getElementsByClassName("photo-holder"));
+    app.FoodEditor.el.addPhoto = Array.from(document.querySelectorAll(".page[data-name='food-editor'] .add-photo"));
+    app.FoodEditor.el.addPhotoCamera = Array.from(document.querySelectorAll(".page[data-name='food-editor'] .add-photo-camera"));
+    app.FoodEditor.el.addPhotoLibrary = Array.from(document.querySelectorAll(".page[data-name='food-editor'] .add-photo-library"));
+    app.FoodEditor.el.photoHolder = Array.from(document.querySelectorAll(".page[data-name='food-editor'] .photo-holder"));
   },
 
   bindUIActions: function() {
@@ -466,59 +466,16 @@ app.FoodEditor = {
     app.FoodEditor.el.quantity.oldValue = app.FoodEditor.el.quantity.value;
   },
 
-  populateImage: function(item) {
+  populateMainImage: function(item) {
     app.FoodEditor.item_image_url = item.image_url;
 
-    app.FoodEditor.el.mainPhoto.style.display = "none";
+    let mainPhotoEl = app.FoodEditor.el.mainPhoto;
+    let addPhotoEl = app.FoodEditor.el.addPhoto[0];
+    let photoHolderEl = app.FoodEditor.el.photoHolder[0];
+    let removable = (app.FoodEditor.origin == "foodlist");
+    let removedCallback = () => app.FoodEditor.removePicture(0);
 
-    if (item.image_url !== undefined && item.image_url !== "" && item.image_url !== "undefined") {
-
-      if (app.Settings.get("foodlist", "show-images")) {
-        let removable = (app.FoodEditor.origin == "foodlist");
-
-        if (item.image_url.startsWith("http")) {
-          let wifiOnly = app.Settings.get("foodlist", "wifi-images");
-          if (app.mode == "development") wifiOnly = false;
-
-          if (navigator.connection.type !== "none") {
-            if ((wifiOnly && navigator.connection.type == "wifi") || !wifiOnly) {
-              let src = unescape(item.image_url);
-              app.FoodEditor.insertImageEl(0, src, removable);
-            }
-          }
-        } else {
-          app.FoodEditor.insertImageEl(0, item.image_url, removable);
-        }
-      }
-    } else if (app.FoodEditor.origin == "foodlist") {
-      app.FoodEditor.el.mainPhoto.style.display = "block";
-      app.FoodEditor.el.addPhoto[0].style.display = "flex";
-      app.FoodEditor.el.photoHolder[0].innerHTML = "";
-    }
-  },
-
-  insertImageEl: function(index, src, removable) {
-    const holder = app.FoodEditor.el.photoHolder[index];
-    holder.innerHTML = "";
-
-    app.FoodEditor.el.mainPhoto.style.display = "block";
-    app.FoodEditor.el.addPhoto[index].style.display = "none";
-
-    let img = document.createElement("img");
-    img.src = src;
-    img.style["max-width"] = "80vw";
-    img.style["max-height"] = "40vh";
-
-    if (removable == true) {
-      holder.classList.add("ripple");
-      img.addEventListener("taphold", function(e) {
-        app.FoodEditor.removePicture(index);
-      });
-    } else {
-      holder.classList.remove("ripple");
-    }
-
-    holder.appendChild(img);
+    app.FoodImages.populateMainImage(mainPhotoEl, addPhotoEl, photoHolderEl, item, removable, removedCallback);
   },
 
   changeServing: function(item, field, newValue) {
@@ -563,87 +520,28 @@ app.FoodEditor = {
   },
 
   takePicture: function(index, sourceType) {
+    let addPhotoEl = app.FoodEditor.el.addPhoto[index];
+    let photoHolderEl = app.FoodEditor.el.photoHolder[index];
+    let addedCallback = (blob) => app.FoodEditor.addPicture(index, blob);
+    let removedCallback = () => app.FoodEditor.removePicture(index);
+    app.FoodImages.takePicture(sourceType, addPhotoEl, photoHolderEl, addedCallback, removedCallback);
+  },
 
-    let destinationType = Camera.DestinationType.FILE_URI;
-
-    // Pictures from the library must be retrieved as base64 data to avoid permission errors
-    if (sourceType === Camera.PictureSourceType.PHOTOLIBRARY)
-      destinationType = Camera.DestinationType.DATA_URL;
-
-    let options = {
-      "sourceType": sourceType,
-      "destinationType": destinationType,
-      "saveToPhotoAlbum": false,
-      "quality": 25
-    };
-
-    navigator.camera.getPicture(onSuccess, onError, options);
-
-    function onSuccess(image) {
-      (async () => {
-
-        let blob;
-        if (sourceType === Camera.PictureSourceType.PHOTOLIBRARY) {
-          let uri = "data:image/jpeg;base64," + image;
-          let res = await fetch(uri);
-          blob = await res.blob();
-        } else {
-          if (app.Settings.get("integration", "edit-images") == true) {
-            let newPath = await app.Utils.cropImage(image);
-            blob = await app.Utils.fileToBlob(newPath);
-          } else {
-            blob = await app.Utils.fileToBlob(image);
-          }
-        }
-
-        if (app.FoodEditor.scan == true) {
-          app.FoodEditor.images[index] = blob;
-        } else {
-          app.f7.preloader.show();
-          let resizedBlob = await app.Utils.resizeImageBlob(blob, "jpeg");
-          let sourceString = await app.Utils.blobToBase64(resizedBlob);
-          app.f7.preloader.hide();
-          app.FoodEditor.item_image_url = sourceString;
-        }
-
-        let blobUrl = URL.createObjectURL(blob);
-        app.FoodEditor.insertImageEl(index, blobUrl, true);
-      })();
-    }
-
-    function onError(err) {
-      let msg = app.strings.dialogs["camera-problem"] || "There was a problem accessing your camera.";
-      app.Utils.toast(msg);
-      console.error(err);
+  addPicture: async function(index, blob) {
+    if (app.FoodEditor.scan == true) {
+      app.FoodEditor.images[index] = blob;
+    } else {
+      let sourceString = await app.FoodImages.imageBlobToBase64(blob);
+      app.FoodEditor.item_image_url = sourceString;
     }
   },
 
   removePicture: function(index) {
-    let title = app.strings.dialogs.delete || "Delete";
-    let text = app.strings.dialogs["confirm-delete"] || "Are you sure you want to delete this?";
-
-    let dialog = app.f7.dialog.create({
-      title: title,
-      content: app.Utils.getDialogTextDiv(text),
-      buttons: [{
-          text: app.strings.dialogs.cancel || "Cancel",
-          keyCodes: app.Utils.escapeKeyCode
-        },
-        {
-          text: app.strings.dialogs.delete || "Delete",
-          keyCodes: app.Utils.enterKeyCode,
-          onClick: () => {
-            app.FoodEditor.el.addPhoto[index].style.display = "flex";
-            app.FoodEditor.el.photoHolder[index].innerHTML = "";
-
-            if (app.FoodEditor.scan == true)
-              app.FoodEditor.images[index] = undefined;
-            else
-              app.FoodEditor.item_image_url = undefined;
-          }
-        }
-      ]
-    }).open();
+    if (app.FoodEditor.scan == true) {
+      app.FoodEditor.images[index] = undefined;
+    } else {
+      app.FoodEditor.item_image_url = undefined;
+    }
   },
 
   gatherFormData: function(data, origin) {
@@ -801,7 +699,7 @@ app.FoodEditor = {
         item.notes = app.FoodEditor.el.notes.value; // Keep local notes, do not overwrite
         app.FoodEditor.populateFields(item);
         if (!barcode.startsWith("fdcId_"))
-          app.FoodEditor.populateImage(item);
+          app.FoodEditor.populateMainImage(item);
         app.FoodEditor.renderNutritionFields(item);
       } else {
         let msg = app.strings.dialogs["no-results"] || "No matching results";

--- a/www/activities/foods-meals-recipes/js/food-images.js
+++ b/www/activities/foods-meals-recipes/js/food-images.js
@@ -1,0 +1,151 @@
+/*
+  Copyright 2024 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+app.FoodImages = {
+
+  populateMainImage: function(mainPhotoEl, addPhotoEl, photoHolderEl, item, removable, removedCallback) {
+    mainPhotoEl.style.display = "none";
+
+    if (item.image_url !== undefined && item.image_url !== "" && item.image_url !== "undefined") {
+
+      if (app.Settings.get("foodlist", "show-images")) {
+        if (item.image_url.startsWith("http")) {
+          let wifiOnly = app.Settings.get("foodlist", "wifi-images");
+          if (app.mode == "development") wifiOnly = false;
+
+          if (navigator.connection.type !== "none") {
+            if ((wifiOnly && navigator.connection.type == "wifi") || !wifiOnly) {
+              mainPhotoEl.style.display = "block";
+              let src = unescape(item.image_url);
+              app.FoodImages.insertImageEl(addPhotoEl, photoHolderEl, src, removable, removedCallback);
+            }
+          }
+        } else {
+          mainPhotoEl.style.display = "block";
+          app.FoodImages.insertImageEl(addPhotoEl, photoHolderEl, item.image_url, removable, removedCallback);
+        }
+      }
+    } else if (removable) {
+      mainPhotoEl.style.display = "block";
+      addPhotoEl.style.display = "flex";
+      photoHolderEl.innerHTML = "";
+    }
+  },
+
+  takePicture: function(sourceType, addPhotoEl, photoHolderEl, addedCallback, removedCallback) {
+
+    let destinationType = Camera.DestinationType.FILE_URI;
+
+    // Pictures from the library must be retrieved as base64 data to avoid permission errors
+    if (sourceType === Camera.PictureSourceType.PHOTOLIBRARY)
+      destinationType = Camera.DestinationType.DATA_URL;
+
+    let options = {
+      "sourceType": sourceType,
+      "destinationType": destinationType,
+      "saveToPhotoAlbum": false,
+      "quality": 25
+    };
+
+    navigator.camera.getPicture(onSuccess, onError, options);
+
+    function onSuccess(image) {
+      (async () => {
+
+        let blob;
+        if (sourceType === Camera.PictureSourceType.PHOTOLIBRARY) {
+          let uri = "data:image/jpeg;base64," + image;
+          let res = await fetch(uri);
+          blob = await res.blob();
+        } else {
+          if (app.Settings.get("integration", "edit-images") == true) {
+            let newPath = await app.Utils.cropImage(image);
+            blob = await app.Utils.fileToBlob(newPath);
+          } else {
+            blob = await app.Utils.fileToBlob(image);
+          }
+        }
+
+        addedCallback(blob);
+
+        let blobUrl = URL.createObjectURL(blob);
+        app.FoodImages.insertImageEl(addPhotoEl, photoHolderEl, blobUrl, true, removedCallback);
+      })();
+    }
+
+    function onError(err) {
+      let msg = app.strings.dialogs["camera-problem"] || "There was a problem accessing your camera.";
+      app.Utils.toast(msg);
+      console.error(err);
+    }
+  },
+
+  removePicture: function(addPhotoEl, photoHolderEl, removedCallback) {
+    let title = app.strings.dialogs.delete || "Delete";
+    let text = app.strings.dialogs["confirm-delete"] || "Are you sure you want to delete this?";
+
+    let dialog = app.f7.dialog.create({
+      title: title,
+      content: app.Utils.getDialogTextDiv(text),
+      buttons: [{
+          text: app.strings.dialogs.cancel || "Cancel",
+          keyCodes: app.Utils.escapeKeyCode
+        },
+        {
+          text: app.strings.dialogs.delete || "Delete",
+          keyCodes: app.Utils.enterKeyCode,
+          onClick: () => {
+            addPhotoEl.style.display = "flex";
+            photoHolderEl.innerHTML = "";
+            removedCallback();
+          }
+        }
+      ]
+    }).open();
+  },
+
+  imageBlobToBase64: async function(blob) {
+    app.f7.preloader.show();
+    let resizedBlob = await app.Utils.resizeImageBlob(blob, "jpeg");
+    let sourceString = await app.Utils.blobToBase64(resizedBlob);
+    app.f7.preloader.hide();
+    return sourceString;
+  },
+
+  insertImageEl: function(addPhotoEl, photoHolderEl, src, removable, removedCallback) {
+    addPhotoEl.style.display = "none";
+    photoHolderEl.innerHTML = "";
+
+    let img = document.createElement("img");
+    img.src = src;
+    img.style["max-width"] = "80vw";
+    img.style["max-height"] = "40vh";
+
+    if (removable == true) {
+      photoHolderEl.classList.add("ripple");
+      img.addEventListener("taphold", function(e) {
+        app.FoodImages.removePicture(addPhotoEl, photoHolderEl, removedCallback);
+      });
+    } else {
+      photoHolderEl.classList.remove("ripple");
+    }
+
+    photoHolderEl.appendChild(img);
+  }
+};

--- a/www/activities/foods-meals-recipes/views/food-editor.html
+++ b/www/activities/foods-meals-recipes/views/food-editor.html
@@ -57,7 +57,7 @@
           <div class="accordion-item-content inline-labels">
             <ul class="form-inputs">
 
-              <li class="item-content" id="main-photo" >
+              <li class="item-content" id="main-photo">
                 <div class="item-inner">
                   <div class="add-photo" style="display:flex;">
                     <span>

--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -105,7 +105,7 @@ app.Meals = {
         let item = app.Meals.list[i];
 
         item.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(item.items, "subtract");
-        app.FoodsMealsRecipes.renderItem(item, app.Meals.el.list, true, false, clickable, app.Meals.gotoEditor, app.Meals.handleTapHold);
+        app.FoodsMealsRecipes.renderItem(item, app.Meals.el.list, true, false, clickable, app.Meals.gotoEditor, app.Meals.handleTapHold, undefined, false, false, "foodlist");
       }
     }
   },

--- a/www/activities/meals/views/meal-editor.html
+++ b/www/activities/meals/views/meal-editor.html
@@ -48,6 +48,25 @@
           </a>
           <div class="accordion-item-content inline-labels">
             <ul class="form-inputs">
+
+              <li class="item-content" id="main-photo">
+                <div class="item-inner">
+                  <div class="add-photo" style="display:flex;">
+                    <span>
+                      <a class="add-photo-camera display-inline-block">
+                        <i class="icon material-icons">add_a_photo</i>
+                      </a>
+                    </span>
+                    <span class="margin-horizontal">
+                      <a class="add-photo-library display-inline-block">
+                        <i class="icon material-icons">add_photo_alternate</i>
+                      </a>
+                    </span>
+                  </div>
+                  <div class="photo-holder block"></div>
+                </div>
+              </li>
+
               <li class="item-content item-input" id="categories-container">
                 <a href="" id="categories">
                   <div class="item-inner">
@@ -68,6 +87,7 @@
                   </div>
                 </div>
               </li>
+
             </ul>
           </div>
         </li>

--- a/www/activities/recipes/js/recipes.js
+++ b/www/activities/recipes/js/recipes.js
@@ -105,7 +105,7 @@ app.Recipes = {
         let item = app.Recipes.list[i];
 
         item.nutrition = await app.FoodsMealsRecipes.getTotalNutrition(item.items, "subtract");
-        app.FoodsMealsRecipes.renderItem(item, app.Recipes.el.list, true, false, clickable, app.Recipes.gotoEditor, app.Recipes.handleTapHold);
+        app.FoodsMealsRecipes.renderItem(item, app.Recipes.el.list, true, false, clickable, app.Recipes.gotoEditor, app.Recipes.handleTapHold, undefined, false, false, "foodlist");
       }
     }
   },

--- a/www/activities/recipes/views/recipe-editor.html
+++ b/www/activities/recipes/views/recipe-editor.html
@@ -48,6 +48,25 @@
           </a>
           <div class="accordion-item-content">
             <ul class="form-inputs">
+
+              <li class="item-content" id="main-photo">
+                <div class="item-inner">
+                  <div class="add-photo" style="display:flex;">
+                    <span>
+                      <a class="add-photo-camera display-inline-block">
+                        <i class="icon material-icons">add_a_photo</i>
+                      </a>
+                    </span>
+                    <span class="margin-horizontal">
+                      <a class="add-photo-library display-inline-block">
+                        <i class="icon material-icons">add_photo_alternate</i>
+                      </a>
+                    </span>
+                  </div>
+                  <div class="photo-holder block"></div>
+                </div>
+              </li>
+
               <li class="item-content item-input inline-labels" id="categories-container">
                 <a href="" id="categories">
                   <div class="item-inner">
@@ -99,6 +118,7 @@
                   </div>
                 </div>
               </li>
+
             </ul>
           </div>
         </li>

--- a/www/index.html
+++ b/www/index.html
@@ -126,6 +126,7 @@
   <script src="activities/diary/js/diary-chart.js"></script>
   <script src="activities/diary/js/group.js"></script>
   <script src="activities/foods-meals-recipes/js/foods-meals-recipes.js"></script>
+  <script src="activities/foods-meals-recipes/js/food-images.js"></script>
   <script src="activities/foods-meals-recipes/js/food-editor.js"></script>
   <script src="activities/foodlist/js/open-food-facts.js"></script>
   <script src="activities/foodlist/js/usda.js"></script>


### PR DESCRIPTION
This adds the ability to take photos of meals and recipes. Just like the existing custom food images, they are stored locally in the app as base64 strings. Closes #812.

In addition, it is now possible to remove pictures imported from OFF and replace them with local images. Closes #811.

**Note: This PR will likely have a small merge conflict with #817. Whichever PR gets merged first, I will fix the conflict in the other one, and then it can also be merged.**

![Screenshot_20240502_093000_Waistline](https://github.com/davidhealey/waistline/assets/19289477/8a613ee7-69de-46b4-a8f7-b7fddf67296c) ![Screenshot_20240502_092933_Waistline](https://github.com/davidhealey/waistline/assets/19289477/5958a5d7-4a96-4828-be0d-11a127b83a3a)

![Screenshot_20240502_093149_Waistline](https://github.com/davidhealey/waistline/assets/19289477/73edd898-3756-45e0-8f5b-9e08b709e397) ![Screenshot_20240502_093141_Waistline](https://github.com/davidhealey/waistline/assets/19289477/015e2484-ca92-4bfa-9f86-20f05017247c)