### PR TITLE
Idea on how to improve raw ingridients search

### DIFF
--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -23,10 +23,15 @@ app.OpenFoodFacts = {
       //Build search string
       let url;
 
+      let barcodeOnlySearch = app.Settings.get("integration", "off-only-barcode") || false;
+
       // If query is a number, assume it's a barcode
-      if (isNaN(query))
+      if (isNaN(query)){
+        // If the user only wants to use OFF for barcode scans return empty list and hope the next provider has the data
+        if (barcodeOnlySearch)
+          return resolve(undefined);
         url = "https://world.openfoodfacts.org/cgi/search.pl?search_terms=" + encodeURIComponent(query) + "&search_simple=1&page_size=50&sort_by=unique_scans_n&action=process&json=1";
-      else
+      } else
         url = "https://world.openfoodfacts.org/api/v0/product/" + encodeURIComponent(query) + ".json";
 
       //Get country name

--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -23,7 +23,8 @@ app.OpenFoodFacts = {
       //Build search string
       let url;
 
-      let barcodeOnlySearch = app.Settings.get("integration", "off-only-barcode") || false;
+      let usdaEnabled = app.Settings.get("integration", "usda") && (app.Settings.get("integration", "usda-key") != "");
+      let barcodeOnlySearch = (app.Settings.get("integration", "off-only-barcode") || false) && usdaEnabled;
 
       // If query is a number, assume it's a barcode
       if (isNaN(query)){

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -756,7 +756,8 @@ app.Settings = {
         "search-language": "Default",
         "search-country": "All",
         "upload-country": "Auto",
-        usda: false
+        usda: false,
+        "off-only-barcode": false
       },
       tts: {
         "speed": 1,

--- a/www/activities/settings/views/integration.html
+++ b/www/activities/settings/views/integration.html
@@ -795,6 +795,20 @@
           </div>
         </li>
 
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
+              <div class="item-title" data-localize="settings.integration.off-only-barcode">Barcode Only Search</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="integration" name="off-only-barcode" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
         <li class="item-divider" data-localize="settings.integration.usda-title">U.S. DEPARTMENT OF AGRICULTURE</li>
 
         <li>


### PR DESCRIPTION
This is an idea on how to improve raw ingredients search when user has both OFF and USDA integrations configured after the conversation in issue #799 .

The idea here is to use OFF only for the barcode scans and any search by product name will only return USDA results.

I do not know how to test it, but the change seems simple enough to me. Feel free to treat this PR as a simple idea that you may certainly improve upon.