### PR TITLE
Add Bulgarian language options in settings

### DIFF
--- a/metadata/en-US/changelogs/30801.txt
+++ b/metadata/en-US/changelogs/30801.txt
@@ -1,3 +1,4 @@
+- added language option for Bulgarian
 - added backup share feature to make the backup file easier to access
 - various bugfixes
 

--- a/www/activities/settings/views/appearance.html
+++ b/www/activities/settings/views/appearance.html
@@ -89,6 +89,7 @@
               <div class="item-input-wrap input-dropdown-wrap">
                 <select id="locale" name="locale" field="appearance" class="reset-modules">
                   <option value="auto" selected data-localize="locale.auto">Detect Automatically</option>
+                  <option value="bg" data-localize="locale.bulgarian">Bulgarian</option>
                   <option value="cs" data-localize="locale.czech">Czech</option>
                   <option value="nl" data-localize="locale.dutch">Dutch</option>
                   <option value="en" data-localize="locale.english">English</option>


### PR DESCRIPTION
Thanks @aeter for adding a Bulgarian translation (at least I assume it was you 😀).

This PR adds Bulgarian as an option to the language dropdown in Appearance settings.