### PR TITLE
Improve local food search by ignoring diacritical marks

### DIFF
--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -252,7 +252,7 @@ app.FoodsMealsRecipes = {
   filterList: function(query, categories, list) {
     let result = list;
 
-    let queryRegExp = query.trim().split(/\s+/).map((w) => {return new RegExp(w, "i")});
+    let queryRegExp = app.Utils.normalizeText(query).trim().split(/\s+/).map((w) => new RegExp(w, "i"));
     let categoriesFilter = categories || [];
 
     // Hidden items should only be shown when a category filter is active
@@ -278,13 +278,16 @@ app.FoodsMealsRecipes = {
           return false; // Hidden items should not be shown but the item is hidden
         }
         if (item.name && item.brand) {
+          const itemName = app.Utils.normalizeText(item.name);
+          const itemBrand = app.Utils.normalizeText(item.brand);
           for (let regExp of queryRegExp) {
-            if (!item.name.match(regExp) && !item.brand.match(regExp))
+            if (!itemName.match(regExp) && !itemBrand.match(regExp))
               return false;
           }
         } else if (item.name) {
+          const itemName = app.Utils.normalizeText(item.name);
           for (let regExp of queryRegExp) {
-            if (!item.name.match(regExp))
+            if (!itemName.match(regExp))
               return false;
           }
         }

--- a/www/assets/js/utils.js
+++ b/www/assets/js/utils.js
@@ -38,6 +38,10 @@ app.Utils = {
     return "";
   },
 
+  normalizeText: function(text) {
+    return text.normalize("NFD").replace(/[\u0300-\u036f]/g, ""); // remove diacritical marks from text, e.g. é -> e
+  },
+
   tidyNumber: function(number, unit) {
     let text = "";
     if (number !== undefined) {


### PR DESCRIPTION
This PR improves the local search by ignoring any diacritical marks (â, é, ü) in both the search query as well as the items being searched.

Examples:
- if you search for "creme", the search results may still include an item called "Crème"
- if you search for "crème", the search results may still include an item called "Creme"

Closes #824.