### PR TITLE
Add confirmation step when leaving editor via back button

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -57,6 +57,7 @@ app.FoodEditor = {
     this.updateTitle();
     this.renderNutritionFields(app.FoodEditor.item);
     this.setComponentVisibility(app.FoodEditor.origin);
+    this.setupHardwareBackButtonExitHandling();
     this.setUploadFieldVisibility();
     this.setRequiredFieldErrorMessage();
     this.setLinkButtonIcon();
@@ -74,6 +75,7 @@ app.FoodEditor = {
   },
 
   getComponents: function() {
+    app.FoodEditor.el.page = document.querySelector(".page[data-name='food-editor']");
     app.FoodEditor.el.title = document.querySelector(".page[data-name='food-editor'] #title");
     app.FoodEditor.el.link = document.querySelector(".page[data-name='food-editor'] #link");
     app.FoodEditor.el.linkIcon = document.querySelector(".page[data-name='food-editor'] #link-icon");
@@ -268,6 +270,13 @@ app.FoodEditor = {
         x.validate = false;
       }
     });
+  },
+
+  setupHardwareBackButtonExitHandling: function() {
+    if (app.FoodEditor.origin == "foodlist")
+      app.FoodEditor.el.page.setAttribute("confirm-backbutton", "");
+    else
+      app.FoodEditor.el.page.removeAttribute("confirm-backbutton");
   },
 
   setRequiredFieldErrorMessage: function() {

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -50,12 +50,14 @@ app.MealEditor = {
       await app.MealEditor.renderItems();
     }
 
+    app.MealEditor.setupHardwareBackButtonExitHandling();
     app.MealEditor.setRequiredFieldErrorMessage();
     app.MealEditor.bindUIActions();
     app.MealEditor.setComponentVisibility();
   },
 
   getComponents: function() {
+    app.MealEditor.el.page = document.querySelector(".page[data-name='meal-editor']");
     app.MealEditor.el.submit = document.querySelector(".page[data-name='meal-editor'] #submit");
     app.MealEditor.el.sort = document.querySelector(".page[data-name='meal-editor'] #sort");
     app.MealEditor.el.categoriesContainer = document.querySelector(".page[data-name='meal-editor'] #categories-container");
@@ -142,6 +144,13 @@ app.MealEditor = {
       });
       app.MealEditor.el.foodlist.hasSortableEvent = true;
     }
+  },
+
+  setupHardwareBackButtonExitHandling: function() {
+    if (app.MealEditor.editingEnabled)
+      app.MealEditor.el.page.setAttribute("confirm-backbutton", "");
+    else
+      app.MealEditor.el.page.removeAttribute("confirm-backbutton");
   },
 
   setRequiredFieldErrorMessage: function() {

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -50,12 +50,14 @@ app.RecipeEditor = {
       await app.RecipeEditor.renderItems();
     }
 
+    app.RecipeEditor.setupHardwareBackButtonExitHandling();
     app.RecipeEditor.setRequiredFieldErrorMessage();
     app.RecipeEditor.bindUIActions();
     app.RecipeEditor.setComponentVisibility();
   },
 
   getComponents: function() {
+    app.RecipeEditor.el.page = document.querySelector(".page[data-name='recipe-editor']");
     app.RecipeEditor.el.submit = document.querySelector(".page[data-name='recipe-editor'] #submit");
     app.RecipeEditor.el.sort = document.querySelector(".page[data-name='recipe-editor'] #sort");
     app.RecipeEditor.el.categoriesContainer = document.querySelector(".page[data-name='recipe-editor'] #categories-container");
@@ -142,6 +144,13 @@ app.RecipeEditor = {
       });
       app.RecipeEditor.el.foodlist.hasSortableEvent = true;
     }
+  },
+
+  setupHardwareBackButtonExitHandling: function() {
+    if (app.RecipeEditor.editingEnabled)
+      app.RecipeEditor.el.page.setAttribute("confirm-backbutton", "");
+    else
+      app.RecipeEditor.el.page.removeAttribute("confirm-backbutton");
   },
 
   setRequiredFieldErrorMessage: function() {

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -95,7 +95,8 @@
     "upload-add-to-foodlist": "Do you want to add the uploaded item to your list of foods?",
     "upload-failed": "Unfortunately the upload failed. Please try again or contact the developer.",
     "what-meal": "What meal is this?",
-    "press-back-again": "Press Back again to exit the app"
+    "press-back-again-exit": "Press Back again to exit the app",
+    "press-back-again-editor": "Press Back again to leave the editor"
   },
   "days": {
     "0": "Sunday",

--- a/www/index.js
+++ b/www/index.js
@@ -531,7 +531,19 @@ $(document).on("blur", "input.auto-select", (e) => {
 });
 
 // Android back button
-let backButtonExitApp = false;
+let backButtonPressedFlag = false;
+const handleBackButtonWithConfirm = (confirmMessage, backAction) => {
+  if (backButtonPressedFlag === true) {
+    backAction();
+    backButtonPressedFlag = false;
+  } else {
+    app.Utils.toast(confirmMessage, 2500, "bottom", () => {
+      backButtonPressedFlag = false;
+    });
+    backButtonPressedFlag = true;
+  }
+}
+
 document.addEventListener("backbutton", (e) => {
 
   let dialogs = document.querySelectorAll(".dialog");
@@ -578,16 +590,14 @@ document.addEventListener("backbutton", (e) => {
   }
 
   let history = new Set(app.f7.views.main.history);
-  if (history.size > 1) {
-    app.f7.views.main.router.back();
-  } else if (backButtonExitApp === true) {
-    navigator.app.exitApp();
+  if (history.size < 2) {
+    let confirmMessage = app.strings.dialogs["press-back-again-exit"] || "Press Back again to exit the app";
+    handleBackButtonWithConfirm(confirmMessage, () => navigator.app.exitApp());
+  } else if (document.querySelector('.page-current').hasAttribute('confirm-backbutton')) {
+    let confirmMessage = app.strings.dialogs["press-back-again-editor"] || "Press Back again to leave the editor";
+    handleBackButtonWithConfirm(confirmMessage, () => app.f7.views.main.router.back());
   } else {
-    backButtonExitApp = true;
-    let msg = app.strings.dialogs["press-back-again"] || "Press Back again to exit the app";
-    app.Utils.toast(msg, 2500, "bottom", () => {
-      backButtonExitApp = false;
-    });
+    app.f7.views.main.router.back();
   }
 });
 


### PR DESCRIPTION
This change prevents users from accidentally leaving the food/meal/recipe editor via the hardware back button and losing all their entered information. Waistline now only exits the editor if the back button is pressed twice in a row within 2.5 seconds. After the first back button press, a banner is shown to inform the user that they have to "Press Back again to leave the editor".

Closes #854.