### PR TITLE
Add option to turn on flashlight by default during barcode scan

### DIFF
--- a/www/activities/foodlist/js/foodlist.js
+++ b/www/activities/foodlist/js/foodlist.js
@@ -471,6 +471,7 @@ app.Foodlist = {
           resolve(undefined);
         }, {
           showTorchButton: true,
+          torchOn: app.Settings.get("integration", "barcode-flashlight"),
           disableSuccessBeep: !app.Settings.get("integration", "barcode-sound"),
           prompt: app.strings["foods-meals-recipes"]["scan-prompt"] || "Place a barcode inside the scan area"
         });

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -751,6 +751,7 @@ app.Settings = {
         "weight": true
       },
       integration: {
+        "barcode-flashlight": false,
         "barcode-sound": false,
         "edit-images": false,
         "search-language": "Default",

--- a/www/activities/settings/views/integration.html
+++ b/www/activities/settings/views/integration.html
@@ -36,6 +36,20 @@
         <li>
           <div class="item-content">
             <div class="item-inner">
+              <div class="item-title" data-localize="settings.integration.barcode-flashlight">Barcode Scan Flashlight</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="integration" name="barcode-flashlight" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
               <div class="item-title" data-localize="settings.integration.barcode-sound">Barcode Scan Beep</div>
               <div class="item-after">
                 <label class="toggle toggle-init">

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -382,6 +382,7 @@
       "import-foods-category-fail": "Please select at least one category",
       "import-success-title": "The backup has been restored",
       "import-success-message": "Import Complete",
+      "barcode-flashlight": "Barcode Scan Flashlight",
       "barcode-sound": "Barcode Scan Beep",
       "edit-images": "Crop Photos",
       "login-success": "Login Successful"


### PR DESCRIPTION
I find myself turning on the camera flashlight pretty much every time I scan a barcode. This PR adds an option to enable the flashlight by default so it's already on immediately after I press the scan button.

The setting can be found under `Settings > Integration` and is disabled by default. But even when it's disabled, users can of course still manually turn on the flashlight via the button shown during the scan (as before).