### PR TITLE
Improve editor hardware back button confirm handling

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -21,6 +21,7 @@ app.FoodEditor = {
 
   item: undefined,
   item_image_url: undefined,
+  addingNewItem: undefined,
   index: undefined,
   scan: false,
   origin: undefined,
@@ -32,10 +33,13 @@ app.FoodEditor = {
 
     app.FoodEditor.item = undefined;
     app.FoodEditor.item_image_url = undefined;
+    app.FoodEditor.addingNewItem = true;
     app.FoodEditor.scan = false;
     app.FoodEditor.images = [];
 
     if (context) {
+
+      app.FoodEditor.addingNewItem = (context.item == undefined || context.item.id == undefined);
 
       if (context.item !== undefined)
         app.FoodEditor.item = context.item;
@@ -43,7 +47,7 @@ app.FoodEditor = {
       if (context.index !== undefined)
         app.FoodEditor.index = context.index;
 
-      if (context.item == undefined || (context.item != undefined && context.item.id == undefined))
+      if (app.FoodEditor.addingNewItem)
         app.FoodEditor.linked = false; //Unlinked by default for adding new items
       else
         app.FoodEditor.linked = true;
@@ -273,7 +277,7 @@ app.FoodEditor = {
   },
 
   setupHardwareBackButtonExitHandling: function() {
-    if (app.FoodEditor.origin == "foodlist")
+    if (app.FoodEditor.addingNewItem)
       app.FoodEditor.el.page.setAttribute("confirm-backbutton", "");
     else
       app.FoodEditor.el.page.removeAttribute("confirm-backbutton");

--- a/www/activities/meals/js/meal-editor.js
+++ b/www/activities/meals/js/meal-editor.js
@@ -19,6 +19,7 @@
 
 app.MealEditor = {
 
+  addingNewMeal: undefined,
   editingEnabled: undefined,
   meal_image_url: undefined,
   meal: {},
@@ -146,7 +147,7 @@ app.MealEditor = {
   },
 
   setupHardwareBackButtonExitHandling: function() {
-    if (app.MealEditor.editingEnabled)
+    if (app.MealEditor.addingNewMeal)
       app.MealEditor.el.page.setAttribute("confirm-backbutton", "");
     else
       app.MealEditor.el.page.removeAttribute("confirm-backbutton");
@@ -338,6 +339,7 @@ document.addEventListener("page:init", function(event) {
     let context = app.data.context;
     app.data.context = undefined;
 
+    app.MealEditor.addingNewMeal = (context == undefined || context.meal == undefined);
     app.MealEditor.editingEnabled = (app.FoodsMealsRecipes.editItems == "enabled");
 
     // Clear old meal

--- a/www/activities/recipes/js/recipe-editor.js
+++ b/www/activities/recipes/js/recipe-editor.js
@@ -19,6 +19,7 @@
 
 app.RecipeEditor = {
 
+  addingNewRecipe: undefined,
   editingEnabled: undefined,
   recipe_image_url: undefined,
   recipe: {},
@@ -146,7 +147,7 @@ app.RecipeEditor = {
   },
 
   setupHardwareBackButtonExitHandling: function() {
-    if (app.RecipeEditor.editingEnabled)
+    if (app.RecipeEditor.addingNewRecipe)
       app.RecipeEditor.el.page.setAttribute("confirm-backbutton", "");
     else
       app.RecipeEditor.el.page.removeAttribute("confirm-backbutton");
@@ -345,6 +346,7 @@ document.addEventListener("page:init", function(event) {
     let context = app.data.context;
     app.data.context = undefined;
 
+    app.RecipeEditor.addingNewRecipe = (context == undefined || context.recipe == undefined);
     app.RecipeEditor.editingEnabled = (app.FoodsMealsRecipes.editItems == "enabled");
 
     // Clear old recipe


### PR DESCRIPTION
I have found the change I made in #858 to be a bit annoying in practice (always having to press the hardware back button twice to leave the food/meal/recipe editor). Therefore, this PR changes the behavior to only require the double press when adding/uploading a new food or meal or recipe (where it is the most annoying to lose all the entered information), but not when editing existing ones.