### PR TITLE
Improve re-download error message on timeout

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -784,7 +784,9 @@ app.FoodEditor = {
           app.FoodEditor.renderNutritionFields(item);
         }
       } else {
-        let msg = app.strings.dialogs["no-results"] || "No matching results";
+        let msg = (result === undefined) ?
+          app.strings.dialogs["no-response"] || "No response from server" :
+          app.strings.dialogs["no-results"] || "No matching results";
         app.Utils.toast(msg);
       }
     }


### PR DESCRIPTION
This improves the error message shown in the food editor when the re-download fails, similar to what I did in ecbff227996ec4439c95c7bb575ad87308f9fd54
I just noticed that I forgot to change it here as well.