### PR TITLE
WIP: Health connect support

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -15,20 +15,26 @@
     <allow-navigation href="*" />
     <allow-intent href="market:*" />
     <platform name="android">
-        <preference name="android-minSdkVersion" value="21" />
-        <preference name="android-compileSdkVersion" value="33" />
-        <preference name="android-targetSdkVersion" value="33" />
+        <preference name="android-minSdkVersion" value="26" />
+        <preference name="android-compileSdkVersion" value="34" />
+        <preference name="android-targetSdkVersion" value="34" />
         <preference name="AndroidPersistentFileLocation" value="Compatibility" />
         <preference name="AndroidExtraFilesystems" value="files,sdcard,cache" />
         <preference name="AndroidInsecureFileModeEnabled" value="true" />
         <preference name="AndroidXEnabled" value="true" />
         <preference name="GradlePluginKotlinEnabled" value="true" />
+        <preference name="GradleVersion" value="8.4" />
+        <preference name="AndroidGradlePluginVersion" value="8.1.1" />
         <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
             <application android:usesCleartextTraffic="true" />
             <application android:requestLegacyExternalStorage="true" />
             <application android:extractNativeLibs="true" />
             <application android:largeHeap="true" />
         </edit-config>
+        <config-file target="AndroidManifest.xml" parent="/*" mode="merge" xmlns:android="http://schemas.android.com/apk/res/android">
+            <uses-permission android:name="android.permission.health.READ_NUTRITION" />
+            <uses-permission android:name="android.permission.health.WRITE_NUTRITION" />
+        </config-file>
         <icon density="ldpi" background="res/icon/android/ldpi-background.png" foreground="res/icon/android/ldpi-foreground.png" monochrome="res/icon/android/ldpi-monochrome.png" src="res/android/ldpi.png" />
         <icon density="mdpi" background="res/icon/android/mdpi-background.png" foreground="res/icon/android/mdpi-foreground.png" monochrome="res/icon/android/mdpi-monochrome.png" src="res/android/mdpi.png" />
         <icon density="hdpi" background="res/icon/android/hdpi-background.png" foreground="res/icon/android/hdpi-foreground.png" monochrome="res/icon/android/hdpi-monochrome.png" src="res/android/hdpi.png" />

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM alvrme/alpine-android:android-33-jdk11
+FROM alvrme/alpine-android:android-34-jdk17
 
 # Set up some environment variables
-ENV GRADLE_VERSION 7.6
+ENV GRADLE_VERSION 8.4
 ENV GRADLE_HOME /opt/gradle-$GRADLE_VERSION
 ENV ANDROID_HOME /opt/sdk
 ENV PATH $PATH:$GRADLE_HOME/bin

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cordova-plugin-crop": "github:rastafan/cordova-plugin-crop",
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-file": "^8.0.0",
-    "cordova-plugin-health": "^3.2.1",
+    "cordova-plugin-health": "https://github.com/samtate/cordova-plugin-health",
     "cordova-plugin-inappbrowser": "^5.0.0",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-network-information": "^3.0.0",
@@ -44,10 +44,7 @@
       "phonegap-plugin-barcodescanner": {
         "ANDROID_SUPPORT_V4_VERSION": "27.+"
       },
-      "cordova-plugin-health": {
-        "HEALTH_READ_PERMISSION": "App needs read access",
-        "HEALTH_WRITE_PERMISSION": "App needs write access"
-      }
+      "cordova-plugin-health": {}
     },
     "platforms": [
       "browser",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "cordova": "^12.0.0",
-    "cordova-android": "^12.0.1",
+    "cordova-android": "^13.0.0",
     "cordova-browser": "^7.0.0",
     "cordova-electron": "^3.1.0",
     "cordova-plugin-browsersync-gen2": "^1.1.7",
@@ -15,6 +15,7 @@
     "cordova-plugin-crop": "github:rastafan/cordova-plugin-crop",
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-file": "^8.0.0",
+    "cordova-plugin-health": "^3.2.1",
     "cordova-plugin-inappbrowser": "^5.0.0",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-network-information": "^3.0.0",
@@ -42,6 +43,10 @@
       "cordova-plugin-x-socialsharing": {},
       "phonegap-plugin-barcodescanner": {
         "ANDROID_SUPPORT_V4_VERSION": "27.+"
+      },
+      "cordova-plugin-health": {
+        "HEALTH_READ_PERMISSION": "App needs read access",
+        "HEALTH_WRITE_PERMISSION": "App needs write access"
       }
     },
     "platforms": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cordova-plugin-crop": "github:rastafan/cordova-plugin-crop",
     "cordova-plugin-device": "^2.0.3",
     "cordova-plugin-file": "^8.0.0",
-    "cordova-plugin-health": "https://github.com/samtate/cordova-plugin-health",
+    "cordova-plugin-health": "https://github.com/dariosalvi78/cordova-plugin-health",
     "cordova-plugin-inappbrowser": "^5.0.0",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-network-information": "^3.0.0",

--- a/www/activities/settings/js/health-connect.js
+++ b/www/activities/settings/js/health-connect.js
@@ -1,0 +1,51 @@
+/*
+  Copyright 2021 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+app.HealthConnect = {
+
+    el: {},
+  
+    init: async function() {
+      this.getComponents();
+      this.bindUIActions();
+      this.toggleVisibility();
+    },
+  
+    getComponents: function() {
+      this.el.disabledList = document.querySelector(".page[data-name='settings-health-connect'] #health-connect-settings-disabled");
+      this.el.enabledList = document.querySelector(".page[data-name='settings-health-connect'] #health-connect-settings-enabled");
+    },
+  
+    bindUIActions: function() {
+    },
+
+    toggleVisibility: function() {
+        if (app.Settings.get("healthConnect", "enabled")) {
+            this.el.enabledList.style.display = "block"
+            this.el.disabledList.style.display = "none"
+        } else {
+            this.el.disabledList.style.display = "block"
+            this.el.enabledList.style.display = "none"
+        }
+    },
+  };
+  
+  document.addEventListener("page:init", function(e) {
+    app.HealthConnect.init();
+  });

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -190,6 +190,29 @@ app.Settings = {
       });
     }
 
+    // Health Connect Settings
+
+    let enableHealthConnect = document.getElementById("enable-health-connect");
+    if (enableHealthConnect) {
+      enableHealthConnect.addEventListener("click", function(e) {
+        app.Settings.enableHealthConnect();
+      });
+    }
+
+    let disableHealthConnect = document.getElementById("disable-health-connect");
+    if (disableHealthConnect) {
+      disableHealthConnect.addEventListener("click", function(e) {
+        app.Settings.disableHealthConnect();
+      });
+    }
+
+    let openHealthConnect = document.getElementById("open-health-connect");
+    if (openHealthConnect) {
+      openHealthConnect.addEventListener("click", function(e) {
+        cordova.plugins.health.openHealthSettings()
+      });
+    }
+
     // Mode
     let modeSelect = document.querySelector(".page[data-name='settings-appearance'] #mode");
 
@@ -270,6 +293,27 @@ app.Settings = {
         app.Settings.put("foodlist", "labels", newOrder);
       });
     }
+  },
+
+  enableHealthConnect: function() {
+    cordova.plugins.health.requestAuthorization({
+      read: ['nutrition'],
+      write: ['nutrition'],
+    }, (result) => {
+      if (result) {
+        app.Settings.put("healthConnect", "enabled", true);
+        app.HealthConnect.toggleVisibility();
+      } else {
+        let msg = app.strings.settings["health-connect"]["permission-fail"] || "Please allow the Nutrition permissions in Health Connect";
+        app.Utils.toast(msg);
+        cordova.plugins.health.openHealthSettings()
+      }
+    },)
+  },
+
+  disableHealthConnect: function() {
+    app.Settings.put("healthConnect", "enabled", false);
+    app.HealthConnect.toggleVisibility();
   },
 
   changeTheme: function(appMode, colourTheme) {
@@ -669,6 +713,9 @@ app.Settings = {
         "show-all-nutriments": false,
         "show-nutrition-units": false,
         "prompt-add-items": false
+      },
+      healthConnect: {
+        "enabled": false,
       },
       foodlist: {
         labels: app.FoodsCategories.defaultLabels,

--- a/www/activities/settings/views/health-connect.html
+++ b/www/activities/settings/views/health-connect.html
@@ -1,0 +1,48 @@
+<!--
+  Copyright 2022 David Healey
+
+  This file is part of Waistline.
+
+  Waistline is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Waistline is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with app.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<div class="page" data-name="settings-health-connect">
+
+  <div class="navbar">
+    <div class="navbar-bg"></div>
+    <div class="navbar-inner">
+      <div class="left">
+        <a class="link back"><i class="icon icon-back"></i></a>
+      </div>
+      <div class="title" data-localize="settings.health-connect.title">Health Connect</div>
+      <div class="right"></div>
+    </div>
+  </div>
+
+  <div class="page-content">
+    <div class="list multi-line-titles">
+      <ul id="health-connect-settings-disabled">
+        <li>
+          <p><a href="#" class="button button-large" id="enable-health-connect" data-localize="settings.health-connect.enable">Enable Health Connect</a></p>
+        </li>
+      </ul>
+      <ul id="health-connect-settings-enabled">
+        <li>
+          <p><a href="#" class="button button-large" id="disable-health-connect" data-localize="settings.health-connect.disable">Disable Health Connect</a></p>
+          <p><a href="#" class="button button-large" id="open-health-connect" data-localize="settings.health-connect.open">Open Health Connect</a></p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/www/activities/settings/views/settings.html
+++ b/www/activities/settings/views/settings.html
@@ -102,6 +102,12 @@
         </li>
 
         <li>
+          <a href="./health-connect/" class="item-link item-content">
+            <div class="item-inner" data-localize="settings.health-connect.title">Health Connect</div>
+          </a>
+        </li>
+
+        <li>
           <a href="./developer/" class="item-link item-content">
             <div class="item-inner" data-localize="settings.developer.title">Developer</div>
           </a>

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -253,6 +253,13 @@
       "centimeters": "Centimeters",
       "inches": "Inches"
     },
+    "health-connect": {
+      "title": "Health Connect",
+      "enable": "Enable Health Connect",
+      "disable": "Disable Health Connect",
+      "open": "Open Health Connect",
+      "permission-fail": "Please allow the Nutrition permissions in Health Connect"
+    },
     "diary": {
       "title": "Diary",
       "categories": "Categories",

--- a/www/index.html
+++ b/www/index.html
@@ -139,6 +139,7 @@
   <script src="activities/settings/js/nutriments.js"></script>
   <script src="activities/settings/js/body-stats.js"></script>
   <script src="activities/settings/js/foods-categories.js"></script>
+  <script src="activities/settings/js/health-connect.js"></script>
   <script src="activities/settings/js/text-so-speech.js"></script>
   <script src="activities/setup-wizard/js/setup-wizard.js"></script>
 </body>

--- a/www/index.js
+++ b/www/index.js
@@ -311,6 +311,13 @@ const app = {
             }
           },
           {
+            path: "health-connect/",
+            url: "activities/settings/views/health-connect.html",
+            options: {
+              transition: "f7-parallax"
+            }
+          },
+          {
             path: "developer/",
             url: "activities/settings/views/developer.html",
             options: {

--- a/www/privacypolicy.html
+++ b/www/privacypolicy.html
@@ -1,0 +1,21 @@
+<h1>Privacy Policy</h1>
+<p>This Privacy Policy explains and gives information regarding the collection, use, and disclosure of personal data when you utilize Waistline and the choices you have associated with that data. By utilizing the software, you accept the terms and conditions of this Policy. This Policy applies to this software and the developer is not responsible for the content or privacy practices on any third-party app not operated by the developer to which this software links or that links to this software.</p>
+
+<h2>Information Collection and Use</h2>
+<p>Waistline only requires the availability of an internet connection when the barcode of a product is scanned, when searching for a product online, or when uploading a product to the Open Food Facts database. During a scan or a search, the only information sent to Open Food Facts or the USDA is the product barcode or the search terms entered.</p>
+<p>For the software to function efficiently camera and storage permissions are required. These are needed to be able to scan barcodes, upload product images, and to import and export data.</p>
+
+<h2>Types of Data Collected</h2>
+<h3>Personal Data</h3>
+<p>No personal data is collected while utilizing the software.</p>
+<h3>Usage Data</h3>
+<p>Usage data is collected only when interacting with the Open Food Facts or USDA databases.</p>
+
+<h2>Security of Data</h2>
+<p>The security of your data is important but no method of transmission over the internet or electronic storage is 100% secure, therefore the developer doesn't guarantee its absolute security.</p>
+
+<h2>Service Providers</h2>
+<p>Waistline requires third-party databases (Open Food Facts and USDA) to facilitate some of its functionality.</p>
+
+<h2>Changes to this Privacy Policy</h2>
+<p>This privacy policy may be updated from time to time as the functionalities of the software are further developed and improved and may contain disparities that will nullify this current policy</p>


### PR DESCRIPTION
Initial development of adding Health Connect Support to the app. Sharing this first stages of development to let maintainers review and make sure they're happy with it so far before I do a lot of work on the feature.

So far I have added the health connect plugin and updated the build environment to the versions required to support Health Connect. I have made a rudimentary settings page where it can be enabled or disabled. I have tested I can send data to Health Connect

Next will be to send your diary data to the API when you enable it, and re-send more when more food is added.