### PR TITLE
Adjust diary goals column count width thresholds

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -311,10 +311,10 @@ app.Diary = {
     // Optimize column count for screen width
     let columnsToShow = 4;
 
-    if (window.innerWidth > 500)
+    if (window.innerWidth > 480)
       columnsToShow = 5;
 
-    if (window.innerWidth < 400)
+    if (window.innerWidth < 360)
       columnsToShow--;
 
     if (app.Settings.get("diary", "show-nutrition-units"))


### PR DESCRIPTION
This lowers the threshold for displaying four goals in the diary from 400 to 360 as discussed in #864.

This is only supposed to be a temporary workaround. A more long-term solution would be to make the order and number of goals displayed in the diary customizable.