### PR TITLE
Fix handling of barcodes with multiple leading zeros

### DIFF
--- a/www/activities/foodlist/js/open-food-facts.js
+++ b/www/activities/foodlist/js/open-food-facts.js
@@ -104,7 +104,13 @@ app.OpenFoodFacts = {
       result.name = item.code;
 
     result.image_url = escape(item.image_url);
-    result.barcode = item.code;
+
+    if (item.code.startsWith("0")) {
+      result.barcode = item.code.substring(1); // if barcode begins with a zero, remove it
+      result.originalBarcode = item.code;
+    } else {
+      result.barcode = item.code;
+    }
 
     // Get first brand if there is more than one
     let brands = item.brands || "";

--- a/www/activities/foodlist/js/usda.js
+++ b/www/activities/foodlist/js/usda.js
@@ -106,6 +106,7 @@ app.USDA = {
     result.name = item.description;
     result.brand = item.brandOwner;
     result.barcode = "fdcId_" + item.fdcId; // Use fdcId as barcode
+    result.originalBarcode = item.fdcId;
     result.portion = "100";
     result.unit = app.strings["unit-symbols"]["g"] || "g";
 

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -445,7 +445,7 @@ app.FoodEditor = {
     app.FoodEditor.el.notes.value = item.notes || "";
 
     if (item.barcode !== undefined && !item.barcode.startsWith("custom_")) {
-      let code = item.barcode.replace("fdcId_", "");
+      let code = item.originalBarcode || item.barcode; // prioritize originalBarcode if it exists, else show normal barcode
 
       app.FoodEditor.el.barcodeContainer.style.display = "block";
       app.FoodEditor.el.barcode.value = code;
@@ -752,15 +752,16 @@ app.FoodEditor = {
 
     if (app.Utils.isInternetConnected()) {
       let barcode = app.FoodEditor.item.barcode;
+      let originalBarcode = app.FoodEditor.item.originalBarcode || app.FoodEditor.item.barcode;
       let result;
 
       app.f7.preloader.show();
 
       if (barcode !== undefined) {
         if (barcode.startsWith("fdcId_"))
-          result = await app.USDA.search(barcode.replace("fdcId_", ""), getNutriments100);
+          result = await app.USDA.search(originalBarcode, getNutriments100);
         else
-          result = await app.OpenFoodFacts.search(barcode, getNutriments100);
+          result = await app.OpenFoodFacts.search(originalBarcode, getNutriments100);
       }
 
       app.f7.preloader.hide();


### PR DESCRIPTION
This implements the suggestion I made in https://github.com/davidhealey/waistline/pull/868#issuecomment-2465065746 and also addresses the concerns raised in https://github.com/davidhealey/waistline/pull/868#issuecomment-2465490929 by keeping the original barcode (with all leading zeros) for display purposes.

Fixes #701.
Fixes #867.
Closes #868.