### PR TITLE
Fix ability to remove images via long press

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-images.js
+++ b/www/activities/foods-meals-recipes/js/food-images.js
@@ -136,10 +136,11 @@ app.FoodImages = {
     img.src = src;
     img.style["max-width"] = "80vw";
     img.style["max-height"] = "40vh";
+    img.style["pointer-events"] = "none";
 
     if (removable == true) {
       photoHolderEl.classList.add("ripple");
-      img.addEventListener("taphold", function(e) {
+      photoHolderEl.addEventListener("taphold", function(e) {
         app.FoodImages.removePicture(addPhotoEl, photoHolderEl, removedCallback);
       });
     } else {


### PR DESCRIPTION
This closes #881. @thebigjoe1 Thank you very much for the bug report!

I have no idea why this feature suddenly stopped working. For some reason, the `taphold` handler must be applied to the container element now. Applying it to the image itself no longer works 🤷