### PR TITLE
Shorten display time of the splash screen

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -43,8 +43,6 @@
         <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />
     </platform>
     <preference name="loadUrlTimeoutValue" value="900000" />
-    <preference name="SplashScreenDelay" value="3000" />
-    <preference name="FadeSplashScreenDuration" value="500" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <hook src="hooks/read_app_version.js" type="after_prepare" />
 </widget>

--- a/metadata/en-US/changelogs/30902.txt
+++ b/metadata/en-US/changelogs/30902.txt
@@ -1,0 +1,2 @@
+- shortened display time of the splash screen
+- various bugfixes


### PR DESCRIPTION
This closes #878.

The approach with manually calling `navigator.splashscreen.hide()` didn't work for some reason. But I was able to shorten the display time of the splash screen by removing the `SplashScreenDelay` property from config.xml. This way, according to the [Cordova docs](https://cordova.apache.org/docs/en/12.x/core/features/splashscreen/index.html#splashscreendelay), the splash screen is automatically hidden when `onPageFinished` has been triggered which seems to be pretty much what we want. On my phone, this reduces the splash screen time to less than two seconds 🤗