### PR TITLE
Add toggleable macro elements summary in category footer to see macro…

### DIFF
--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -151,7 +151,7 @@ app.Group = {
     if (grams === undefined || isNaN(grams)) {
       return null;
     } else {
-      const nutrimentPrefix = nutriment.charAt(0).toUpperCase();
+      const nutrimentPrefix = app.strings["nutriments-abbreviations"][nutriment] || nutriment.charAt(0).toUpperCase();
       return nutrimentPrefix + app.Utils.tidyNumber(Math.round(grams));
     }
   },

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -130,10 +130,10 @@ app.Group = {
     });
 
     let categoryMacroNutriments = app.Settings.get("diary", "show-macro-nutriments-summary") ? [
-      this.getMacroNutrimentFooterText('F', nutrition.fat, categoryEnergyTotal),
-      this.getMacroNutrimentFooterText('C', nutrition.carbohydrates, categoryEnergyTotal),
-      this.getMacroNutrimentFooterText('P', nutrition.proteins, categoryEnergyTotal)
-    ].filter(text => text !== '') : [];
+      this.getMacroNutrimentFooterText('fat', nutrition.fat, categoryEnergyTotal),
+      this.getMacroNutrimentFooterText('carbohydrates', nutrition.carbohydrates, categoryEnergyTotal),
+      this.getMacroNutrimentFooterText('proteins', nutrition.proteins, categoryEnergyTotal)
+    ].filter(text => text !== null) : [];
 
     right.innerText = categoryMacroNutriments.join(' / ') +
         (categoryMacroNutriments.length > 0 ? ' / ' : '') +
@@ -141,14 +141,18 @@ app.Group = {
     row.appendChild(right);
   },
 
-  getMacroNutrimentFooterText: function(prefix/*: string*/, grams/*: number | undefined*/, categoryEnergyTotal/*: number*/) {
+  getMacroNutrimentFooterText: function (nutriment/*: string*/, grams/*: number | undefined*/, categoryEnergyTotal/*: number*/) {
     if (categoryEnergyTotal === 0) {
-      return '';
+      return null;
+    }
+    if (!app.Goals.showInDiary(nutriment)) {
+      return null;
     }
     if (grams === undefined || isNaN(grams)) {
-      return '';
-    }  else {
-      return prefix  + app.Utils.tidyNumber(Math.round(grams));
+      return null;
+    } else {
+      const nutrimentPrefix = nutriment.charAt(0).toUpperCase();
+      return nutrimentPrefix + app.Utils.tidyNumber(Math.round(grams));
     }
   },
 

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -148,7 +148,7 @@ app.Group = {
     if (grams === undefined || isNaN(grams)) {
       return '';
     }  else {
-      return prefix  + Math.round(grams);
+      return prefix  + app.Utils.tidyNumber(Math.round(grams));
     }
   },
 

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -151,8 +151,8 @@ app.Group = {
     if (grams === undefined || isNaN(grams)) {
       return null;
     } else {
-      const nutrimentPrefix = app.strings["nutriments-abbreviations"][nutriment] || nutriment.charAt(0).toUpperCase();
-      return nutrimentPrefix + app.Utils.tidyNumber(Math.round(grams));
+      const nutrimentAbbreviation = app.strings["nutriments-abbreviations"][nutriment] || nutriment.charAt(0).toUpperCase();
+      return  app.Utils.tidyNumber(Math.round(grams)) + ' ' + nutrimentAbbreviation;
     }
   },
 

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -129,19 +129,19 @@ app.Group = {
       app.Diary.showCategoryNutriments(id, nutrition);
     });
 
-    let macroElementsTexts = app.Settings.get("diary", "show-macro-elements-summary") ? [
-      this.getMacroElementFooterText('F', nutrition.fat, categoryEnergyTotal),
-      this.getMacroElementFooterText('C', nutrition.carbohydrates, categoryEnergyTotal),
-      this.getMacroElementFooterText('P', nutrition.proteins, categoryEnergyTotal)
+    let categoryMacroNutriments = app.Settings.get("diary", "show-macro-nutriments-summary") ? [
+      this.getMacroNutrimentFooterText('F', nutrition.fat, categoryEnergyTotal),
+      this.getMacroNutrimentFooterText('C', nutrition.carbohydrates, categoryEnergyTotal),
+      this.getMacroNutrimentFooterText('P', nutrition.proteins, categoryEnergyTotal)
     ].filter(text => text !== '') : [];
 
-    right.innerText = macroElementsTexts.join(' / ') +
-        (macroElementsTexts.length > 0 ? ' / ' : '') +
+    right.innerText = categoryMacroNutriments.join(' / ') +
+        (categoryMacroNutriments.length > 0 ? ' / ' : '') +
         app.Utils.tidyNumber(Math.round(categoryEnergyTotal), energyUnitSymbol);
     row.appendChild(right);
   },
 
-  getMacroElementFooterText: function(prefix/*: string*/, grams/*: number | undefined*/, categoryEnergyTotal/*: number*/) {
+  getMacroNutrimentFooterText: function(prefix/*: string*/, grams/*: number | undefined*/, categoryEnergyTotal/*: number*/) {
     if (categoryEnergyTotal === 0) {
       return '';
     }

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -30,7 +30,7 @@ app.Group = {
     let ul = document.createElement("ul");
     list.appendChild(ul);
 
-    //Collapsable list item 
+    //Collapsable list item
     let li = document.createElement("li");
     li.className = "accordion-item";
 
@@ -94,7 +94,7 @@ app.Group = {
     row.className = "row item-content";
     li.appendChild(row);
 
-    //Add button 
+    //Add button
     let left = document.createElement("div");
     left.className = "add-button";
     left.id = "add-button-" + id;
@@ -116,21 +116,40 @@ app.Group = {
     icon.innerText = "add";
     a.appendChild(icon);
 
-    //Energy 
+    //Energy
     const energyUnit = app.Settings.get("units", "energy");
     const energyName = app.Utils.getEnergyUnitName(energyUnit);
 
     let right = document.createElement("div");
     right.className = "margin-horizontal group-energy link icon-only";
-    let value = nutrition[energyName] || 0;
+    let categoryEnergyTotal = nutrition[energyName] || 0;
     let energyUnitSymbol = app.strings["unit-symbols"][energyUnit] || energyUnit;
 
     right.addEventListener("click", function(e) {
       app.Diary.showCategoryNutriments(id, nutrition);
     });
 
-    right.innerText = app.Utils.tidyNumber(Math.round(value), energyUnitSymbol);
+    let macroElementsTexts = app.Settings.get("diary", "show-macro-elements-summary") ? [
+      this.getMacroElementFooterText('P', nutrition.proteins, categoryEnergyTotal),
+      this.getMacroElementFooterText('F', nutrition.fat, categoryEnergyTotal),
+      this.getMacroElementFooterText('C', nutrition.carbohydrates, categoryEnergyTotal)
+    ].filter(text => text !== '') : [];
+
+    right.innerText = macroElementsTexts.join(' / ') +
+        (macroElementsTexts.length > 0 ? ' / ' : '') +
+        app.Utils.tidyNumber(Math.round(categoryEnergyTotal), energyUnitSymbol);
     row.appendChild(right);
+  },
+
+  getMacroElementFooterText: function(prefix/*: string*/, grams/*: number | undefined*/, categoryEnergyTotal/*: number*/) {
+    if (categoryEnergyTotal === 0) {
+      return '';
+    }
+    if (grams === undefined || isNaN(grams)) {
+      return '';
+    }  else {
+      return prefix  + Math.round(grams);
+    }
   },
 
   addItem: function(item) {

--- a/www/activities/diary/js/group.js
+++ b/www/activities/diary/js/group.js
@@ -130,9 +130,9 @@ app.Group = {
     });
 
     let macroElementsTexts = app.Settings.get("diary", "show-macro-elements-summary") ? [
-      this.getMacroElementFooterText('P', nutrition.proteins, categoryEnergyTotal),
       this.getMacroElementFooterText('F', nutrition.fat, categoryEnergyTotal),
-      this.getMacroElementFooterText('C', nutrition.carbohydrates, categoryEnergyTotal)
+      this.getMacroElementFooterText('C', nutrition.carbohydrates, categoryEnergyTotal),
+      this.getMacroElementFooterText('P', nutrition.proteins, categoryEnergyTotal)
     ].filter(text => text !== '') : [];
 
     right.innerText = macroElementsTexts.join(' / ') +

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -667,7 +667,7 @@ app.Settings = {
         "show-thumbnails": false,
         "wifi-thumbnails": true,
         "show-all-nutriments": false,
-        "show-macro-elements-summary": false,
+        "show-macro-nutriments-summary": false,
         "show-nutrition-units": false,
         "prompt-add-items": false
       },

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -146,7 +146,7 @@ app.Settings = {
       });
     }
 
-    // Import/Export 
+    // Import/Export
     let exportDb = document.getElementById("export-db");
     if (exportDb) {
       exportDb.addEventListener("click", function(e) {
@@ -221,7 +221,7 @@ app.Settings = {
       locale.hasSecondaryChangeEvent = true;
     }
 
-    // Animations 
+    // Animations
     let toggleAnimations = document.querySelector(".page[data-name='settings-appearance'] #toggle-animations");
 
     if (toggleAnimations != undefined && !toggleAnimations.hasSecondaryChangeEvent) {
@@ -232,7 +232,7 @@ app.Settings = {
       toggleAnimations.hasSecondaryChangeEvent = true;
     }
 
-    // Nutriment list 
+    // Nutriment list
     let nutrimentList = document.getElementById("nutriment-list");
     if (nutrimentList != undefined) {
       nutrimentList.addEventListener("sortable:sort", (li) => {
@@ -245,7 +245,7 @@ app.Settings = {
       });
     }
 
-    // Body stats list 
+    // Body stats list
     let bodyStatsList = document.getElementById("body-stats-list");
     if (bodyStatsList != undefined) {
       bodyStatsList.addEventListener("sortable:sort", (li) => {
@@ -667,6 +667,7 @@ app.Settings = {
         "show-thumbnails": false,
         "wifi-thumbnails": true,
         "show-all-nutriments": false,
+        "show-macro-elements-summary": false,
         "show-nutrition-units": false,
         "prompt-add-items": false
       },
@@ -850,8 +851,8 @@ app.Settings = {
         settings.statistics["last-stat"] = lastStat;
       }
       window.localStorage.removeItem("last-stat");
-      
-      // Show Brands setting should be initialized to "true", as is the historical default behaviour 
+
+      // Show Brands setting should be initialized to "true", as is the historical default behaviour
       if (settings.diary["show-brands"] === undefined) {
         settings.diary["show-brands"] = true;
       }
@@ -914,7 +915,7 @@ document.addEventListener("page:init", async function(e) {
 
   if (pageName == "settings-nutriments")
     app.Nutriments.populateNutrimentList();
-  
+
   if (pageName == "settings-body-stats")
     app.BodyStats.populateBodyStatsList();
 

--- a/www/activities/settings/views/diary.html
+++ b/www/activities/settings/views/diary.html
@@ -126,6 +126,20 @@
         <li>
           <div class="item-content">
             <div class="item-inner">
+              <div class="item-title" data-localize="settings.diary.show-macro-elements-summary">Show macros summary per category</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="diary" name="show-macro-elements-summary" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
               <div class="item-title" data-localize="settings.diary.prompt-add-items">Prompt for quantity when adding items</div>
               <div class="item-after">
                 <label class="toggle toggle-init">

--- a/www/activities/settings/views/diary.html
+++ b/www/activities/settings/views/diary.html
@@ -126,10 +126,10 @@
         <li>
           <div class="item-content">
             <div class="item-inner">
-              <div class="item-title" data-localize="settings.diary.show-macro-elements-summary">Show macros summary per category</div>
+              <div class="item-title" data-localize="settings.diary.show-macro-nutriments-summary">Show macros summary per category</div>
               <div class="item-after">
                 <label class="toggle toggle-init">
-                  <input type="checkbox" field="diary" name="show-macro-elements-summary" />
+                  <input type="checkbox" field="diary" name="show-macro-nutriments-summary" />
                   <span class="toggle-icon"></span>
                 </label>
               </div>

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -49,6 +49,11 @@
     "fructose": "Fructose",
     "lactose": "Lactose"
   },
+  "nutriments-abbreviations": {
+    "fat": "F",
+    "carbohydrates": "C",
+    "proteins": "P"
+  },
   "unit-symbols": {
     "kcal": "kcal",
     "kJ": "kJ",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -262,7 +262,8 @@
       "wifi-thumbnails": "Only show thumbnails over Wi-Fi",
       "show-all-nutriments": "Show all nutrients on Overview page",
       "show-units": "Show nutrition units",
-      "prompt-add-items": "Prompt for quantity when adding items"
+      "prompt-add-items": "Prompt for quantity when adding items",
+      "show-macro-nutriments-summary": "Show macros summary per category"
     },
     "nutriments": {
       "title": "Nutrients",

--- a/www/assets/locales/locale-pl.json
+++ b/www/assets/locales/locale-pl.json
@@ -262,8 +262,7 @@
       "wifi-thumbnails": "Pokazuj miniatury tylko przez Wi-Fi",
       "show-all-nutriments": "Pokaż wszystkie składniki odżywcze na stronie podglądu",
       "show-units": "Pokaż jednostki odżywcze",
-      "prompt-add-items": "Pytaj o ilość podczas dodawania produktów",
-      "show-macro-nutriments-summary": "Pokazuj podsumowanie makroelementów per kategoria"
+      "prompt-add-items": "Pytaj o ilość podczas dodawania produktów"
     },
     "nutriments": {
       "title": "Składniki odżywcze",

--- a/www/assets/locales/locale-pl.json
+++ b/www/assets/locales/locale-pl.json
@@ -263,7 +263,7 @@
       "show-all-nutriments": "Pokaż wszystkie składniki odżywcze na stronie podglądu",
       "show-units": "Pokaż jednostki odżywcze",
       "prompt-add-items": "Pytaj o ilość podczas dodawania produktów",
-      "show-macro-elements-summary": "Pokazuj podsumowanie makroelementów per kategoria"
+      "show-macro-nutriments-summary": "Pokazuj podsumowanie makroelementów per kategoria"
     },
     "nutriments": {
       "title": "Składniki odżywcze",

--- a/www/assets/locales/locale-pl.json
+++ b/www/assets/locales/locale-pl.json
@@ -262,7 +262,8 @@
       "wifi-thumbnails": "Pokazuj miniatury tylko przez Wi-Fi",
       "show-all-nutriments": "Pokaż wszystkie składniki odżywcze na stronie podglądu",
       "show-units": "Pokaż jednostki odżywcze",
-      "prompt-add-items": "Pytaj o ilość podczas dodawania produktów"
+      "prompt-add-items": "Pytaj o ilość podczas dodawania produktów",
+      "show-macro-elements-summary": "Pokazuj podsumowanie makroelementów per kategoria"
     },
     "nutriments": {
       "title": "Składniki odżywcze",


### PR DESCRIPTION
… elements per meal easily

# Before
I found it hard to see how much protein and other macros I should add to particular meal (category). I could achieve that by clicking on calories button and see category nutriments. Then after closing the dialog I could already forget macros values. And it required way too many clicks.

# After
There is:
- new Diary setting called 'Show macros summary per category'. Turned off by default
- macro nutriments summary next to calories, e.g. 'P15 / F20/ C52 400 kcal'. Prefixes stand for protein, fat, carbohydrate.
- displaying macro nutriments summary is aligned with goal displaying in diary footer. e.g. if fat is not displayed in the diary footer, it won't be displayed in category summary

![image](https://github.com/user-attachments/assets/cb1a5916-c977-4cae-a9d8-94d43b29b3be)

![image](https://github.com/user-attachments/assets/072a34ff-26d4-4fab-8447-c761724efb2e)

![image](https://github.com/user-attachments/assets/a4839b57-1d82-41d3-9e28-c9fba5663b94)


I know there are missing translations, but I don't want to invest too much upfront in this pull request without knowing the likelihood of merging it.