### PR TITLE
Add support to addition expression in portion size

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -618,7 +618,7 @@ app.Diary = {
 
           let input = document.createElement("input");
           input.className = "dialog-input auto-select";
-          input.type = "number";
+          input.type = "tel";
           if (field == "serving-size")
             input.setAttribute("value", item.portion || "");
           else

--- a/www/activities/foods-meals-recipes/js/food-editor.js
+++ b/www/activities/foods-meals-recipes/js/food-editor.js
@@ -17,6 +17,35 @@
   along with app.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+
+
+function evalInpEquation(strIn)
+{
+  let ret = 0;
+  let strInTmp = strIn.trim();
+
+  if (strInTmp.length == 0 || strInTmp == "+" || strInTmp == "-")
+    return NaN;
+
+  let cleanStr = strInTmp.replaceAll("+", " + ").replaceAll("-", " - ").replaceAll("  ", " ");
+  let tokens = cleanStr.split(/\s+/);
+
+  if (tokens[0] == "" && (tokens[1] == "+" || tokens[1] == "-"))
+      tokens[0] = "0";
+
+  ret = parseInt(tokens[0]);
+  for (let i = 1; i < (tokens.length - 1); i+=2)
+  {
+    if (tokens[i] == "+")
+        ret += (parseInt(tokens[i+1]) || 0);
+    else if (tokens[i] == "-")
+        ret -= (parseInt(tokens[i+1]) || 0);
+  }
+
+  return ret;
+}
+
+
 app.FoodEditor = {
 
   item: undefined,
@@ -126,6 +155,22 @@ app.FoodEditor = {
     app.FoodEditor.el.portion.addEventListener("change", (e) => {
       if (e.target.oldValue == undefined && e.target.value != 0)
         e.target.oldValue = e.target.value;
+
+      // Force to only allow the given pattern as input
+      if (!app.FoodEditor.el.portion.validity.valid)
+      {
+        e.target.value = e.target.oldValue;
+        return;
+      }
+
+      if (!/^\d+$/.test(e.target.value))
+      {
+        let newValue = evalInpEquation(e.target.value)
+        if (!isNaN(newValue))
+        {
+          e.target.value = newValue;
+        }
+      }
     });
 
     // Quantity

--- a/www/activities/foods-meals-recipes/views/food-editor.html
+++ b/www/activities/foods-meals-recipes/views/food-editor.html
@@ -133,7 +133,7 @@
                     <label for="portion" data-localize="food-editor.serving-size">Serving Size</label>
                   </div>
                   <div class="item-input-wrap">
-                    <input class="align-end auto-select" type="number" min="0" step="any" id="portion" name="portion" required validate>
+                    <input class="align-end auto-select" type="tel" pattern="[0-9]+[\+\-0-9]*" id="portion" name="portion" required validate>
                   </div>
                 </div>
               </li>


### PR DESCRIPTION
Allow users to add up two or more numbers in the portion size. This is useful for meals that don't consist of equal portion sizes

Imagine cooking something like a chili. Not every serving will be the same size, so you weigh each serving.
Instead of adding a new serving each time you go to the pot or calculating the weight in your head, you can now simply add the current portion size to the existing one by entering "250+186" and automatically have the new weight.


Note: I'm not a JS developer, so please feel free to suggest better approaches.