### PR TITLE
Add total portion size of an item to the diary view

### DIFF
--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -568,9 +568,11 @@ app.FoodsMealsRecipes = {
 
             portion.innerText += app.Utils.tidyNumber(parseFloat(item.quantity));
 
-            let totalPortionSize = item.portion * item.quantity;
-            let totalPortionSizeText = " (= " + app.Utils.tidyNumber(parseFloat(totalPortionSize), item.unit) + ")";
-            portion.innerText += totalPortionSizeText;
+            if (app.Settings.get("diary", "show-total-portion-size") == true) {
+              let totalPortionSize = item.portion * item.quantity;
+              let totalPortionSizeText = " (= " + app.Utils.tidyNumber(parseFloat(totalPortionSize), item.unit) + ")";
+              portion.innerText += totalPortionSizeText;
+            }
           }
 
           inner.appendChild(portion);

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -567,6 +567,10 @@ app.FoodsMealsRecipes = {
               portion.innerText += " \u00D7 "; // times symbol
 
             portion.innerText += app.Utils.tidyNumber(parseFloat(item.quantity));
+
+            let totalPortionSize = item.portion * item.quantity;
+            let totalPortionSizeText = " (= " + app.Utils.tidyNumber(parseFloat(totalPortionSize), item.unit) + ")";
+            portion.innerText += totalPortionSizeText;
           }
 
           inner.appendChild(portion);

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -669,7 +669,8 @@ app.Settings = {
         "show-all-nutriments": false,
         "show-macro-nutriments-summary": false,
         "show-nutrition-units": false,
-        "prompt-add-items": false
+        "prompt-add-items": false,
+        "show-total-portion-size": false
       },
       foodlist: {
         labels: app.FoodsCategories.defaultLabels,

--- a/www/activities/settings/views/diary.html
+++ b/www/activities/settings/views/diary.html
@@ -151,6 +151,20 @@
           </div>
         </li>
 
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
+              <div class="item-title" data-localize="settings.diary.show-total-portion-size">Show Total Portion Size</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="diary" name="show-total-portion-size" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
       </ul>
     </div>
 

--- a/www/assets/locales/locale-de.json
+++ b/www/assets/locales/locale-de.json
@@ -268,7 +268,8 @@
       "show-all-nutriments": "Alle Nährstoffe auf Übersichtsseite anzeigen",
       "show-units": "Nährstoffeinheiten anzeigen",
       "prompt-add-items": "Beim Hinzufügen von Einträgen Menge abfragen",
-      "show-macro-nutriments-summary": "Makro-Nährstoffe pro Kategorie anzeigen"
+      "show-macro-nutriments-summary": "Makro-Nährstoffe pro Kategorie anzeigen",
+      "show-total-portion-size": "Gesamtportionsgröße anzeigen"
     },
     "nutriments": {
       "title": "Nährstoffe",

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -268,7 +268,8 @@
       "show-all-nutriments": "Show all nutrients on Overview page",
       "show-units": "Show nutrition units",
       "prompt-add-items": "Prompt for quantity when adding items",
-      "show-macro-nutriments-summary": "Show macros summary per category"
+      "show-macro-nutriments-summary": "Show macros summary per category",
+      "show-total-portion-size": "Show Total Portion Size"
     },
     "nutriments": {
       "title": "Nutrients",


### PR DESCRIPTION
Display the total portion size (item.portion * item.quantity) of items in the diary view. See the following image for a few examples:

<img width="348" height="434" alt="2025-07-16_12-41" src="https://github.com/user-attachments/assets/10828878-9526-451f-bd26-4e48fc25708f" />

Implements feature request in issue #809.