### PR TITLE
Add linear regression trend line to statistics 

### DIFF
--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -658,7 +658,8 @@ app.Settings = {
       statistics: {
         "y-zero": false,
         "average-line": true,
-        "goal-line": true
+        "goal-line": true,
+        "trend-line": false
       },
       diary: {
         "meal-names": ["Breakfast", "Lunch", "Dinner", "Snacks", "", "", ""],

--- a/www/activities/settings/views/statistics.html
+++ b/www/activities/settings/views/statistics.html
@@ -72,6 +72,20 @@
             </div>
           </div>
         </li>
+
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
+              <div class="item-title" data-localize="settings.statistics.trend-line">Show Trend Line</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" id="trend-line" field="statistics" name="trend-line" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -290,13 +290,27 @@ app.Stats = {
       inner.appendChild(after);
     }
 
+    if (app.Settings.get("statistics", "trend-line") == true && app.Stats.data.trend !== undefined) {
+      let trend = app.Stats.renderTrend(app.Stats.data.trend.slope, app.Stats.data.dataset.unit);
+      app.Stats.el.timeline.prepend(trend);
+    }
+    
     let avg = app.Stats.renderAverage(app.Stats.data.average, app.Stats.data.dataset.unit);
     app.Stats.el.timeline.prepend(avg);
   },
 
   renderAverage: function(average, unit) {
-    let roundedAverage = Math.round(average * 100) / 100;
+    let averageInfoName = app.strings.statistics["average"] || "Average";
+    return app.Stats.renderTimelineInfo(averageInfoName, average, unit);
+  },
 
+  renderTrend: function(trendSlope, unit) {
+    let trendInfoName = app.strings.statistics["trend"] || "Trend";
+    return app.Stats.renderTimelineInfo(trendInfoName, trendSlope, unit);
+  },
+
+  renderTimelineInfo: function(infoName, infoValue, infoUnit) {
+    let roundedValue = Math.round(infoValue * 100) / 100;
     let li = document.createElement("li");
 
     let content = document.createElement("div");
@@ -309,12 +323,12 @@ app.Stats = {
 
     let title = document.createElement("div");
     title.className = "item-title";
-    title.innerText = app.strings.statistics["average"] || "Average";
+    title.innerText = infoName;
     inner.appendChild(title);
 
     let after = document.createElement("div");
     after.className = "item-after";
-    after.innerText = app.Utils.tidyNumber(roundedAverage, unit);
+    after.innerText = app.Utils.tidyNumber(roundedValue, infoUnit);
     inner.appendChild(after);
 
     return li;

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -140,7 +140,8 @@
     "waist": "Waist",
     "hips": "Hips",
     "body fat": "Body Fat",
-    "average": "Average"
+    "average": "Average",
+    "trend": "Trend"
   },
   "diary": {
     "title": "Diary",
@@ -322,7 +323,8 @@
       "title": "Statistics",
       "y-zero": "Begin Y Axis at Zero",
       "average-line": "Show Average Line",
-      "goal-line": "Show Goal Line"
+      "goal-line": "Show Goal Line",
+      "trend-line": "Show Trend Line"
     },
     "developer": {
       "title": "Developer",


### PR DESCRIPTION
Adds a trend line for the statistics chart and displays the trend/slope the selected stat is following. 

Preview:
<img width="353" height="782" alt="2025-07-16_20-16" src="https://github.com/user-attachments/assets/34f9bd91-0327-4241-bdc3-5d0a06e2f519" />
The trend line is the orange dashed line. It is calculated using the method of least squares. The resulting formula (y = mx + b) gets used to draw a line between `x_0` and `x_n` (n = size of selected data set).
The slope/trend (m of the formula above) gets displayed in the timeline like the calculated average of the stat. 

Conditions: 
- To display the trend line, it needs to be enabled in the settings.
- There need to be at least 2 data points for the selected stat in the selected time frame.

This implements the feature request in #890.