### PR TITLE
Allow takeover from all categories of the past day

### DIFF
--- a/www/activities/meals/js/meals.js
+++ b/www/activities/meals/js/meals.js
@@ -123,10 +123,26 @@ app.Meals = {
 
       // Get yesterday's meal if there is a diary category
       let category = app.FoodsMealsRecipes.getCategory();
-      let yesterdaysMeal = false;
 
-      if (category !== false) {
-        yesterdaysMeal = await app.Meals.getYesterdaysMeal(category);
+      let startCategory = 0;
+      let endCategory = 0;
+      const mealNames = await app.Settings.get("diary", "meal-names");
+      if (app.Settings.get("foodlist", "add-leftovers") !== true)
+      {
+        startCategory = category;
+        endCategory = category;
+      }
+      else
+        startCategory = mealNames.length;
+
+      for (let meal =startCategory; meal >= endCategory ; meal--)
+      {
+        if (mealNames[meal] == "" || mealNames[meal] == undefined)
+          continue;
+
+        let yesterdaysMeal = false;
+
+        yesterdaysMeal = await app.Meals.getYesterdaysMeal(meal);
 
         // Add meal to top of list
         if (yesterdaysMeal)

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -682,7 +682,8 @@ app.Settings = {
         "wifi-thumbnails": true,
         "show-images": true,
         "wifi-images": true,
-        "show-notes": false
+        "show-notes": false,
+        "add-leftovers": false,
       },
       goals: {
         migrated: true,

--- a/www/activities/settings/views/foods.html
+++ b/www/activities/settings/views/foods.html
@@ -137,6 +137,20 @@
           </div>
         </li>
 
+        <li>
+          <div class="item-content">
+            <div class="item-inner">
+              <div class="item-title" data-localize="settings.foods.add-leftovers">Show past day's meals of all categories</div>
+              <div class="item-after">
+                <label class="toggle toggle-init">
+                  <input type="checkbox" field="foodlist" name="add-leftovers" />
+                  <span class="toggle-icon"></span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+
       </ul>
     </div>
 

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -311,7 +311,8 @@
       "wifi-thumbnails": "Only show thumbnails over Wi-Fi",
       "images": "Show Food Images",
       "wifi-images": "Only show images over Wi-Fi",
-      "show-notes": "Show Food Notes"
+      "show-notes": "Show Food Notes",
+      "add-leftovers": "Show past day's meals of all categories"
     },
     "foods-categories": {
       "title": "Labels and Categories",


### PR DESCRIPTION
This is to allow users to take over not only from the same category from the last day, but also from others.
The goal is to allow an easy takeover of leftovers of for example yesterday's dinner as today's lunch.

Since not everybody might want that I've made it optional and added a settings entry to control this feature. It is disabled by default.