### PR TITLE
Distinguish rate limit and network errors from invalid USDA keys

### DIFF
--- a/www/activities/foodlist/js/usda.js
+++ b/www/activities/foodlist/js/usda.js
@@ -212,18 +212,35 @@ app.USDA = {
       let url = "https://api.nal.usda.gov/fdc/v1/foods/search?api_key=" + encodeURIComponent(key) + "&query=cheese";
 
       let response = await app.Utils.timeoutFetch(url).catch((err) => {
-        resolve(false);
+        resolve({
+          valid: false,
+          reason: "network"
+        });
       });
 
-      if (response && response.ok) {
-        let data = await response.json();
-        if (data.error && data.error.code == "API_KEY_INVALID")
-          resolve(false);
-        else
-          resolve(true);
-      }
+      if (response) {
+        if (response.ok) {
+          resolve({
+            valid: true
+          });
+        } else {
+          let data = await response.json().catch((err) => undefined);
+          let code = data && data.error && data.error.code;
 
-      resolve(false);
+          let reason;
+          if (code == "OVER_RATE_LIMIT" || response.status == 429)
+            reason = "rate-limit";
+          else if (code == "API_KEY_INVALID" || response.status == 403)
+            reason = "invalid-key";
+          else
+            reason = "network";
+
+          resolve({
+            valid: false,
+            reason: reason
+          });
+        }
+      }
     });
   }
 };

--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -346,10 +346,18 @@ app.Settings = {
   saveUSDAKey: async function(key) {
     let screen = document.querySelector(".usda-login");
     if (app.Utils.isInternetConnected()) {
-      if (key == "" || await app.USDA.testApiKey(key)) {
+      let result = key == "" ? { valid: true } : await app.USDA.testApiKey(key);
+
+      if (result.valid) {
         this.put("integration", "usda-key", key);
         app.f7.loginScreen.close(screen);
         let msg = app.strings.settings.integration["login-success"] || "Login Successful";
+        app.Utils.toast(msg);
+      } else if (result.reason == "rate-limit") {
+        let msg = app.strings.settings.integration["usda-rate-limited"] || "USDA rate limit reached, try again later";
+        app.Utils.toast(msg);
+      } else if (result.reason == "network") {
+        let msg = app.strings.settings.integration["usda-key-check-failed"] || "Couldn't verify key, check your connection and try again";
         app.Utils.toast(msg);
       } else {
         let msg = app.strings.settings.integration["invalid-api-key"] || "API Key Invalid";

--- a/www/assets/locales/locale-en.json
+++ b/www/assets/locales/locale-en.json
@@ -395,6 +395,8 @@
       "save": "Save",
       "invalid-credentials": "Invalid Credentials",
       "invalid-api-key": "API Key Invalid",
+      "usda-rate-limited": "USDA rate limit reached, try again later",
+      "usda-key-check-failed": "Couldn't verify key, check your connection and try again",
       "export-success": "Database Exported",
       "export-fail": "Export Failed",
       "import-fail": "Import Failed",


### PR DESCRIPTION
Fixes #947.

`testApiKey()` only ever resolved true or false, so any non-2xx response got collapsed into the same "invalid" result. In practice that meant a rate-limited key and an actually-bad key showed the identical "API Key Invalid" toast. I hit the live USDA API to check what a rate limit actually looks like: a valid `DEMO_KEY` past its limit comes back as HTTP 429 with `error.code: "OVER_RATE_LIMIT"`, completely different from the 403 / `API_KEY_INVALID` a bad key gets. The old code had no way to tell those apart.

There was a second problem in the same branch: anything that wasn't a rate limit fell straight through to "invalid-key". That includes a USDA outage (5xx), a malformed/non-JSON response, or any other api.data.gov error code. So someone with a perfectly good key would get told their key is wrong during an outage, which is really the same bug as the rate-limit case, just a different trigger.

The fix picks the reason from both the response status and the error code: 403 or `API_KEY_INVALID` means the key itself is bad, 429 or `OVER_RATE_LIMIT` means rate-limited, and anything else (including unknown or server errors) falls back to a "couldn't verify, check your connection" message instead of "API Key Invalid". `testApiKey` now resolves `{ valid, reason }` instead of a bare boolean, and `saveUSDAKey` shows the message that matches the actual reason.

Verified locally with a standalone Node script hitting the real USDA endpoint (not through Cordova, just plain fetch against the same URL testApiKey builds): a garbage key comes back invalid-key, hammering DEMO_KEY until it 429s comes back rate-limit, and pointing the request at a host that doesn't resolve comes back network. All three matched what the mapping is supposed to produce.

I ran this against Cordova's browser platform (`cordova platform add browser`, `cordova run browser`) rather than a real Android device, so I can't confirm behavior on-device, just that the logic and messages are correct.
