### PR TITLE
Translate remaining language names in pt locale

### DIFF
--- a/www/assets/locales/locale-pt.json
+++ b/www/assets/locales/locale-pt.json
@@ -407,23 +407,23 @@
   "locale": {
     "auto": "Detectar automaticamente",
     "bulgarian": "Búlgaro",
-    "czech": "Czech",
-    "dutch": "Dutch",
+    "czech": "Tcheco",
+    "dutch": "Holandês",
     "english": "Inglês",
     "finnish": "Finlandês",
     "french": "Francês",
     "german": "Alemão",
     "hebrew": "Hebraico",
     "italian": "Italiano",
-    "polish": "Polish",
+    "polish": "Polonês",
     "portuguese": "Português",
-    "romanian": "Romanian",
+    "romanian": "Romeno",
     "russian": "Russo",
-    "serbian-cyrillic": "Serbian (Cyrillic)",
-    "serbian-latin": "Serbian (Latin)",
+    "serbian-cyrillic": "Sérvio (Cirílico)",
+    "serbian-latin": "Sérvio (Latino)",
     "spanish": "Espanhol",
     "swedish": "Sueco",
-    "turkish": "Turkish",
-    "ukrainian": "Ukrainian"
+    "turkish": "Turco",
+    "ukrainian": "Ucraniano"
   }
 }


### PR DESCRIPTION
Fixes 8 language names in the `locale` section of `locale-pt.json` that were still showing raw English instead of Portuguese in the language picker: czech, dutch, polish, romanian, serbian-cyrillic, serbian-latin, turkish, ukrainian.

Used the standard Portuguese terms, matching the Brazilian register the rest of the file already uses (búlgaro, alemão, hebraico, etc.):

- czech -> Tcheco
- dutch -> Holandês
- polish -> Polonês
- romanian -> Romeno
- serbian-cyrillic -> Sérvio (Cirílico)
- serbian-latin -> Sérvio (Latino)
- turkish -> Turco
- ukrainian -> Ucraniano

Checked each against the Portuguese Wikipedia article for the language (e.g. pt.wikipedia.org/wiki/Língua_tcheca, /wiki/Língua_romena, /wiki/Língua_sérvia). Tcheco/tcheca and polonês are the Brazilian forms specifically (European Portuguese uses checo/polaco), which lines up with the rest of the file already being Brazilian Portuguese (usuário, not utilizador). The "(Script)" format for the two Serbian variants mirrors what locale-ru.json already ships for the same keys (Сербский (Кириллица) / Сербский (Латиница)).

Only touched the `locale` object, no other strings changed.
