### PR TITLE
Translate USDA department title in pl locale

### DIFF
--- a/www/assets/locales/locale-pl.json
+++ b/www/assets/locales/locale-pl.json
@@ -365,7 +365,7 @@
       "all-countries": "Wszystkie",
       "default": "Domyślne",
       "auto": "Wykrywaj automatycznie",
-      "usda-title": "U.S. DEPARTMENT OF AGRICULTURE",
+      "usda-title": "Departament Rolnictwa Stanów Zjednoczonych",
       "usda": "Włącz wyszukiwanie w USDA",
       "usda-login-title": "USDA",
       "usda-api": "USDA API",


### PR DESCRIPTION
`locale-pl.json` had the USDA integration title left as raw English ("U.S. DEPARTMENT OF AGRICULTURE") while 12 other shipped locales (de, es, fr, nl, pt, he, bg, sr, sr-CS, tr, ru, it) already translate this same key with the department's full name.

Changed settings.integration.usda-title to "Departament Rolnictwa Stanów Zjednoczonych", the name used by Polish Wikipedia's own article on the USDA.

One-line change, nothing else touched.
