### PR TITLE
Fix edge-to-edge layout gaps on Android 16 (#977)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -37,7 +37,6 @@
         <icon density="xxxhdpi" background="res/icon/android/xxxhdpi-background.png" foreground="res/icon/android/xxxhdpi-foreground.png" monochrome="res/icon/android/xxxhdpi-monochrome.png" src="res/android/xxxhdpi.png" />
         <preference name="AndroidWindowSplashScreenAnimatedIcon" value="res/screen/android/splashscreen.xml" />
         <preference name="AndroidWindowSplashScreenBackground" value="#973939" />
-        <preference name="AndroidPostSplashScreenTheme" value="@style/Theme.AppCompat.DayNight.NoActionBar" />
     </platform>
     <platform name="electron">
         <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />


### PR DESCRIPTION
## Summary
- Fixes #977: after updating to 3.11.1 (targetSdk 36), users on Android 16 see large empty margins above and below the app content.
- Removes the `AndroidPostSplashScreenTheme` preference from `config.xml`, which pinned the post-splash activity theme to plain `Theme.AppCompat.DayNight.NoActionBar`.

## Root cause
Cordova-Android's own template theme for the post-splash activity is:

```xml
<style name="Theme.Cordova.App.DayNight" parent="Theme.AppCompat.DayNight.NoActionBar">
    <item name="android:colorBackground">@color/cdv_background_color</item>
    <item name="android:statusBarColor">@android:color/transparent</item>
</style>
```

`SystemBarPlugin` (Cordova-Android's internal edge-to-edge/system-bar handler, new since 15.0.0) recomputes system bar insets exactly at the point the app transitions from the splash-screen theme to this post-splash theme. Waistline's `config.xml` overrode that theme to the bare `Theme.AppCompat.DayNight.NoActionBar` parent, dropping the `android:statusBarColor`/`android:colorBackground` attributes `SystemBarPlugin` relies on.

That override predates Cordova-Android's own `Theme.Cordova.App.DayNight` default (added later) and was presumably only needed originally to get NoActionBar styling, which the current default already provides. On Android 15 the app could still opt out of edge-to-edge entirely (`AndroidWindowOptOutEdgeToEdgeEnforcement` defaulted to true), which likely masked this. On Android 16 that opt-out no longer exists — edge-to-edge is mandatory — so the missing theme attributes cause `SystemBarPlugin` to miscompute the reserved system-bar space, producing the blank margins reported in the issue.

## Fix
Remove the `AndroidPostSplashScreenTheme` override so Cordova-Android's own default theme (which already includes NoActionBar styling plus the attributes `SystemBarPlugin` expects) is used instead.

## Test plan
- [ ] Build and install on an Android 16 device (the reporter has a Samsung S21 FE) and confirm the app fills the screen correctly with no blank top/bottom margins.
- [ ] Sanity check on an older Android version (e.g. Android 13/14) to confirm no regression in status bar / layout appearance.
- [ ] Confirm splash screen and post-splash transition still look correct (background color, no ActionBar flash).

I wasn't able to build/run the Android app in this environment, so this needs a real-device test before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NBvux6Lsi4nZosXs6wBJax)_