### PR TITLE
Fix Edge-To-Edge on Android 16

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -18,6 +18,7 @@
         <preference name="android-minSdkVersion" value="21" />
         <preference name="android-compileSdkVersion" value="36" />
         <preference name="android-targetSdkVersion" value="36" />
+        <preference name="AndroidEdgeToEdge" value="true" />
         <preference name="AndroidPersistentFileLocation" value="Compatibility" />
         <preference name="AndroidExtraFilesystems" value="files,sdcard,cache" />
         <preference name="AndroidInsecureFileModeEnabled" value="true" />
@@ -37,7 +38,6 @@
         <icon density="xxxhdpi" background="res/icon/android/xxxhdpi-background.png" foreground="res/icon/android/xxxhdpi-foreground.png" monochrome="res/icon/android/xxxhdpi-monochrome.png" src="res/android/xxxhdpi.png" />
         <preference name="AndroidWindowSplashScreenAnimatedIcon" value="res/screen/android/splashscreen.xml" />
         <preference name="AndroidWindowSplashScreenBackground" value="#973939" />
-        <preference name="AndroidPostSplashScreenTheme" value="@style/Theme.AppCompat.DayNight.NoActionBar" />
     </platform>
     <platform name="electron">
         <preference name="ElectronSettingsFilePath" value="res/electron/settings.json" />

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM alvrme/alpine-android:android-35-jdk17
+FROM alvrme/alpine-android:android-36-jdk17
 
 # Set up some environment variables
-ENV GRADLE_VERSION=8.13
+ENV GRADLE_VERSION=8.14.2
 ENV GRADLE_HOME=/opt/gradle-$GRADLE_VERSION
 ENV ANDROID_HOME=/opt/sdk
 ENV PATH=$PATH:$GRADLE_HOME/bin
@@ -15,9 +15,6 @@ RUN curl -L https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin
     rm -f gradle-$GRADLE_VERSION-bin.zip && \
     ln -s gradle-$GRADLE_VERSION gradle
 RUN npm install -g cordova
-
-# Because some commands ask if we want to opt in
-RUN cordova telemetry off
 
 # Go to app directory
 WORKDIR /waistline/app


### PR DESCRIPTION
I just updated the Dockerfile for Android 16 (SDK 36) and built the app. I can reproduce the layout problem described in #977 on my Samsung phone running Android 16.

But the change proposed in #978 doesn't fix the problem for me. I was able to fix it by adding the `AndroidEdgeToEdge` preference in config.xml. However, I don't know if this has any negative implications for devices still running older versions of Android. It would be good to test this before making a new release.

Here is the debug APK I built: [app-debug.zip](https://github.com/user-attachments/files/31174771/app-debug.zip)

Closes #977
Closes #982