### PR TITLE
Fix edge-to-edge layout gaps on Android 16 via AndroidEdgeToEdge (#977)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -23,6 +23,7 @@
         <preference name="AndroidInsecureFileModeEnabled" value="true" />
         <preference name="AndroidXEnabled" value="true" />
         <preference name="GradlePluginKotlinEnabled" value="true" />
+        <preference name="AndroidEdgeToEdge" value="true" />
         <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
             <application android:usesCleartextTraffic="true" />
             <application android:requestLegacyExternalStorage="true" />

--- a/www/index.html
+++ b/www/index.html
@@ -21,7 +21,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="Content-Security-Policy" content="default-src * data: ws: blob: gap; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
-  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="theme-color" content="#2196f3"> <!-- Color theme for statusbar (Android only) -->
 


### PR DESCRIPTION
## Summary
- Fixes #977: blank top/bottom margins on Android 16 after updating to 3.11.1 (targetSdk 36).
- Supersedes the earlier `AndroidPostSplashScreenTheme` fix in #978, which was confirmed on-device *not* to fix it.
- Adds `<preference name="AndroidEdgeToEdge" value="true" />` to `config.xml` (confirmed by the reporter/maintainer to fix the Android 16 layout on-device).
- Adds `viewport-fit=cover` to the viewport meta tag in `www/index.html`.

## Why both changes are needed
`AndroidEdgeToEdge=true` fixes Android 16, but it isn't version-gated — it applies on every Android version the app runs on (`minSdkVersion` 21). Looking at Cordova-Android's `CordovaActivity.java`, when this preference is on, the margins Cordova used to reserve for the status bar and nav bar all become `0`, on every OS version, not just 16. Cordova-Android's built-in system bar plugin doesn't expose any inset values back to the web layer to compensate (no CSS variables, no JS API for it) — so on its own, this change would trade the Android 16 bug for a milder version of the same problem on Android 7–14 (Framework7's navbar/toolbar could end up partly behind the status bar or a classic 3-button nav bar).

Framework7 (already used throughout this app) already has full support for this built in: `--f7-safe-area-top`/`--f7-safe-area-bottom` CSS variables are wired through its navbar height, page padding, and `.toolbar-bottom` sizing across its whole stylesheet, driven by `env(safe-area-inset-*)`. The only thing missing was `viewport-fit=cover` on the viewport meta tag — without it, browsers report `0` for `env(safe-area-inset-*)` regardless of the real window insets. Adding it lets Framework7's existing layout math handle safe areas correctly and consistently on every Android version, with no custom CSS needed.

## Test plan
- [x] Confirmed by the reporter: `AndroidEdgeToEdge=true` alone fixes the Android 16 layout on a real device (Samsung S21 FE).
- [ ] Build and install with both changes together and re-confirm no blank margins on Android 16.
- [ ] Check an older Android version (e.g. Android 13/14) to confirm the navbar/toolbar aren't overlapped by the status bar or navigation bar now that Cordova's own margin padding is disabled.
- [ ] Check landscape orientation / a device with a display cutout, since left/right insets are also affected by `AndroidEdgeToEdge`.

I wasn't able to build/run the Android app in this environment, so this still needs a real-device test before merging — particularly the older-Android and landscape/cutout cases, which weren't covered by the reporter's Android 16 test.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NBvux6Lsi4nZosXs6wBJax)_