### PR TITLE
Fix Statistics date range reading dates through the wrong timezone lens

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -37,8 +37,9 @@ app.DiaryChart = {
     this.bindUIActions();
 
     let date = context.date;
-    
-    this.dbData = await app.Stats.getDataFromDb(date, date);
+    let utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+
+    this.dbData = await app.Stats.getDataFromDb(utcDate, utcDate);
 
     if (this.dbData.timestamps.length > 0) {
       let data = await this.organiseData(this.dbData);

--- a/www/activities/statistics/js/statistics.js
+++ b/www/activities/statistics/js/statistics.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 David Healey
+  Copyright 2021-2026 David Healey
 
   This file is part of Waistline.
 
@@ -611,10 +611,8 @@ app.Stats = {
       }
 
       // Make date range inclusive of the whole days at either end
-      let toDate = new Date(Date.UTC(to.getFullYear(), to.getMonth(), to.getDate()));
-      toDate.setHours(0, 0, 0, 0);
-      let fromDate = new Date(Date.UTC(from.getFullYear(), from.getMonth(), from.getDate()));
-      fromDate.setHours(0, 0, 0, 0);
+      let toDate = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()));
+      let fromDate = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()));
       toDate.setUTCHours(toDate.getUTCHours() + 24);
 
       dbHandler.getIndex("dateTime", "diary").openCursor(IDBKeyRange.bound(fromDate, toDate, false, true)).onsuccess = function(e) {


### PR DESCRIPTION
Fixes #979

Hey folks, this is the fix I mentioned over on #979.

## What was going wrong

`getDataFromDb()` in `www/activities/statistics/js/statistics.js` builds the start/end of the query range from the dates you pick on the Statistics screen. Those incoming dates are UTC, but the code was reading them back out with the *local* year/month/day getters instead of the UTC ones — so it re-read the date through the wrong lens partway through. For anyone in a timezone behind UTC (the Americas, mostly), that shift lands you on the previous day, which is exactly the off-by-one folks were seeing.

## The fix

Swapped the local getters (`getFullYear`/`getMonth`/`getDate`) for their UTC equivalents (`getUTCFullYear`/`getUTCMonth`/`getUTCDate`) when rebuilding the range boundaries, so the day read back actually matches the day encoded in the original timestamp. I also dropped the local `setHours(0, 0, 0, 0)` calls right after — `Date.UTC()` already gives you midnight, so those were just reintroducing the same local/UTC mix-up a line later. 

## Testing

Ran it in a browser (`cordova run browser`) with the timezone set behind UTC (America/New_York), since this one only shows up west of Greenwich:
- Seeded a diary entry for "today" straight into IndexedDB.
- Set the Statistics From/To range to today ? today.
- With the fix, that entry shows up. Running the old logic side-by-side against the same data, it computes a range shifted a day earlier and comes back empty — so this does reproduce and fix the reported behavior.

No console errors either way.

Still finding my feet with the contribution process here, so let me know if I've missed anything or if you'd rather this shaped differently — happy to adjust.

Cheers