### PR TITLE
Fix CSV diary export only includes today

### DIFF
--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2020, 2021 David Healey
+  Copyright 2020-2026 David Healey
 
   This file is part of Waistline.
 
@@ -545,7 +545,7 @@ app.Settings = {
     });
 
     // Get diary data
-    let diaryData = await app.Stats.getDataFromDb(new Date(), undefined);
+    let diaryData = await app.Stats.getDataFromDb(new Date(0), undefined);
     let csv = "";
 
     // CSV header row


### PR DESCRIPTION
Fixes #980

**Issue**
`writeDiaryToCsvFile()` in www/activities/settings/js/settings.js calls `getDataFromDb(new Date(), undefined)`, which resolves to a date range of today through today. So the CSV export only ever includes today.

**Solution**
Updated the call to use a from parameter of `new Date(0)` which resolves to the beginning of epoch time, creating a date range of start of time through today. Creating a full diary export.

**Testing**
Ran the project in an Android emulator.
- Seeded the database by importing from a backup.
- Ran the Export Diary to CSV function with the pre and post change code.
- Before the fix the diary only included the current day. After the fix the diary included one row for each day

Cheers

