### PR TITLE
Fix diary nutrition chart code pulls extra data

### DIFF
--- a/www/activities/diary/js/diary-chart.js
+++ b/www/activities/diary/js/diary-chart.js
@@ -37,8 +37,8 @@ app.DiaryChart = {
     this.bindUIActions();
 
     let date = context.date;
-
-    this.dbData = await app.Stats.getDataFromDb(date, 0);
+    
+    this.dbData = await app.Stats.getDataFromDb(date, date);
 
     if (this.dbData.timestamps.length > 0) {
       let data = await this.organiseData(this.dbData);


### PR DESCRIPTION
Fixes #984

**Issue**
diary-chart.js calls `getDataFromDb(date, 0)` which resolves to a date range of the specified date through the current date. The code is intended to pull for only the specified day, but actually calls all data covering the specified date through the current date. The extra data does not surface to the user because the code calls `getTotalNutrition(data.items[0], "ignore")`, which only processes the first row of data, i.e. data for the specified date.

**Solution**
Updated the call to use `getDataFromDb(date, date)` which resolves to a date range of the specified date only.

**Testing**
Ran the project in an Android emulator.
- Seeded the database by importing from a backup.
- Diary chart display on an old date with the pre and post change code, and with additional debug statements to validate dates and data.
- Before the fix the data pull returned extra unnecessary data. After the fix the data pull returned for only the specified date.
- The chart displayed was the same in all cases.

Cheers