### PR TITLE
Fix OpenFoodFacts password stored in exported JSON

### DIFF
--- a/www/activities/settings/js/settings.js
+++ b/www/activities/settings/js/settings.js
@@ -423,6 +423,18 @@ app.Settings = {
 
     let data = await dbHandler.export();
     data.settings = JSON.parse(window.localStorage.getItem("settings"));
+
+    if ("off-password" in data.settings.integration) {
+      data.settings.integration["off-password"] = "";
+    }
+
+    if ("usda-key" in data.settings.integration) {
+      data.settings.integration["usda-key"] = "";
+    }
+
+    if ("icu-key" in data.settings.integration) {
+      data.settings.integration["icu-key"] = "";
+    }
     let json = JSON.stringify(data);
 
     let filename = "waistline_export.json";


### PR DESCRIPTION
Fixes #871

**Issue**
Function `writeDatabaseBackupToFile` in settings.js retrieves settings from local storage and includes the values in the JSON export. The export can include sensitive data in plain text.

**Solution**
Updated the function to clear values for `off-password`, `usda-key` and `icu-key` if they exist, before exporting.

**Testing**
Ran the project in an Android emulator.
- Seeded the database by importing from a backup.
- Tested the export function before and after code change, examined and compared the JSON files produced.
- Reviewed the Integration settings before and after exporting to confirm settings remain unchanged in the app.
- Before the fix the export included the target data, after the fix those fields were rendered as "".

Cheers