### PR TITLE
Fix Image is automatically rotated 90 degrees when added when in port…

### DIFF
--- a/www/activities/foods-meals-recipes/js/food-images.js
+++ b/www/activities/foods-meals-recipes/js/food-images.js
@@ -60,7 +60,8 @@ app.FoodImages = {
       "sourceType": sourceType,
       "destinationType": destinationType,
       "saveToPhotoAlbum": false,
-      "quality": 25
+      "quality": 25,
+      "correctOrientation": true
     };
 
     navigator.camera.getPicture(onSuccess, onError, options);


### PR DESCRIPTION
Fixes #611

**Issue**
Function `takePicture` in food-images.js uses the Cordova camera plugin to take photos.
Apparently a [quirk of the plugin](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-camera/#CameraOptions-quirks) sets the `correctOrientation` to false by default.

**Solution**
Updated the options to set `correctOrientation` to true.

**Testing**
Ran the application using adb and a Pixel 8.
- Tested the camera  function before and after the code change.
- Before the fix the photographs rendered in landscape, after the fix the photos rendered as taken.

Cheers