### PR TITLE
Expanding checkbox area

### DIFF
--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -81,3 +81,8 @@ div.food-thumbnail > img {max-width: 100%; max-height: 12em;}
   --f7-theme-color-shade: #151c1f;
   --f7-theme-color-tint: #354851;
 }
+
+.item-checkbox .icon-checkbox {
+  margin-left: 16px;
+  --f7-checkbox-extra-margin: 16px;
+}

--- a/www/assets/css/global-styles.css
+++ b/www/assets/css/global-styles.css
@@ -83,6 +83,6 @@ div.food-thumbnail > img {max-width: 100%; max-height: 12em;}
 }
 
 .item-checkbox .icon-checkbox {
-  margin-left: 16px;
+  margin-left: 6px;
   --f7-checkbox-extra-margin: 16px;
 }


### PR DESCRIPTION
Fixes #969, #802, #439

**Issue**
Users report difficulty clicking the foodlist checkbox, reporting that the area to tap is too slim. Expanding the checkbox area a small amount is the most agreeable solution.

**Solution**
Updated the checkbox styling to include additional padding.

**Testing**
- Ran the application using adb and a Pixel 8.
- Tested the clickability of the foodlist for a couple of days.
- Zero misclicks experienced, display is still practical and readable, all other functionality unchanged.

**Before**
<img width="540" height="1200" alt="969-before" src="https://github.com/user-attachments/assets/640680c0-f1cc-495e-bfb8-feeb426b02d8" />

**After**
<img width="540" height="1200" alt="969-after" src="https://github.com/user-attachments/assets/8b38157e-6854-4f11-8dc3-5a57d675292e" />
