### PR TITLE
Add capability to switch the food selection button from add to select

### DIFF
--- a/www/activities/diary/js/diary.js
+++ b/www/activities/diary/js/diary.js
@@ -282,6 +282,10 @@ app.Diary = {
     let container = document.querySelector("#diary-day");
     container.innerHTML = "";
 
+    // Expand the target group's card when returning here after adding items to it
+    if (scrollPosition !== undefined && scrollPosition.category !== undefined && app.Diary.groups[scrollPosition.category] !== undefined)
+      app.Diary.groups[scrollPosition.category].collapsed = false;
+
     for (group in app.Diary.groups)
       await app.Diary.groups[group].render(container);
 

--- a/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
+++ b/www/activities/foods-meals-recipes/js/foods-meals-recipes.js
@@ -67,6 +67,7 @@ app.FoodsMealsRecipes = {
     app.FoodsMealsRecipes.el.scan = document.querySelector(".page[data-name='foods-meals-recipes'] #scan");
     app.FoodsMealsRecipes.el.title = document.querySelector(".page[data-name='foods-meals-recipes'] #title");
     app.FoodsMealsRecipes.el.fab = document.querySelector(".page[data-name='foods-meals-recipes'] #add-item");
+    app.FoodsMealsRecipes.el.fab.icon = document.querySelector(".page[data-name='foods-meals-recipes'] #add-item-icon");
   },
 
   bindUIActions: function() {
@@ -78,18 +79,22 @@ app.FoodsMealsRecipes = {
 
     // Fab button 
     app.FoodsMealsRecipes.el.fab.addEventListener("click", function(e) {
-      switch (app.FoodsMealsRecipes.tab) {
-        case "foodlist":
-          app.Foodlist.gotoEditor();
-          break;
+      if (app.FoodsMealsRecipes.selection.length > 0) {
+        app.FoodsMealsRecipes.submitButtonClickEventHandler();
+      } else {
+        switch (app.FoodsMealsRecipes.tab) {
+          case "foodlist":
+            app.Foodlist.gotoEditor();
+            break;
 
-        case "meals":
-          app.Meals.gotoEditor();
-          break;
-
-        case "recipes":
-          app.Recipes.gotoEditor();
-          break;
+          case "meals":
+            app.Meals.gotoEditor();
+            break;
+            
+          case "recipes":
+            app.Recipes.gotoEditor();
+            break;
+        }
       }
     });
   },
@@ -643,9 +648,11 @@ app.FoodsMealsRecipes = {
 
   updateSelectionCount: async function() {
     if (!app.FoodsMealsRecipes.selection.length) {
+      app.FoodsMealsRecipes.el.fab.icon.innerText = "add";
       app.FoodsMealsRecipes.el.submit.style.display = "none";
       app.FoodsMealsRecipes.el.title.innerText = app.FoodsMealsRecipes.tabTitle;
     } else {
+      app.FoodsMealsRecipes.el.fab.icon.innerText = "check";
       app.FoodsMealsRecipes.el.submit.style.display = "block";
 
       // Get energy for selection

--- a/www/activities/foods-meals-recipes/views/foods-meals-recipes.html
+++ b/www/activities/foods-meals-recipes/views/foods-meals-recipes.html
@@ -62,7 +62,7 @@
 
   <!-- Floating Action Button -->
   <div class="fab fab-right-bottom new-item" id="add-item">
-    <a href="#"><i class="icon material-icons">add</i></a>
+    <a href="#"><i id="add-item-icon" class="icon material-icons">add</i></a>
   </div>
 
 </div>


### PR DESCRIPTION
Addresses #891

**Issue**
User requested on the Food-Meals-Recipe page: when one or more food items are selected the primary bottom-right button should become a check mark and pivot to selecting rather than adding function.

**Solution**
Updated the action button to switch icons based on element selection and to execute the indicated functionality.

**Testing**
- Ran the application using adb and a Pixel 8.
- Tested the updated food selection user interface for a couple of days.
- The UI rendered as intended, the button was functional in both add and select modes, all other functionality unchanged.

**Before**
<img width="540" height="1200" alt="891-before" src="https://github.com/user-attachments/assets/61afbd9f-acaf-42c6-b680-082ddf5e3fdb" />

**After**
<img width="540" height="1200" alt="891-after-1" src="https://github.com/user-attachments/assets/8286b3d6-1dd9-4319-bc2c-f6a1c131b005" />
<br/>
<img width="540" height="1200" alt="891-after-2" src="https://github.com/user-attachments/assets/1d923d07-6dca-432a-b1ba-0c724f2c3c9f" />
